### PR TITLE
Strict warning disabling checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please ADD ALL Changes to the UNRELASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Added
+- Prohibition of non white-listed #pragma warning disables
 ### Fixed
 ### Changed
 ### Removed

--- a/src/FunFair.CodeAnalysis.Tests/ProhibitedPragmasDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ProhibitedPragmasDiagnosticsAnalyzerTests.cs
@@ -1,0 +1,60 @@
+using FunFair.CodeAnalysis.Tests.Helpers;
+using FunFair.CodeAnalysis.Tests.Verifiers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace FunFair.CodeAnalysis.Tests
+{
+    public sealed class ProhibitedPragmasDiagnosticsAnalyzerTests : CodeFixVerifier
+    {
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new ProhibitedPragmasDiagnosticsAnalyzer();
+        }
+
+        [Fact]
+        public void AllowedWarningIsNotAnError()
+        {
+            const string test = @"#pragma warning disable 8618";
+            this.VerifyCSharpDiagnostic(test);
+        }
+
+        [Fact]
+        public void BannedWarningCannotBeDisabled()
+        {
+            const string test = @"#pragma warning disable 1234";
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0008",
+                                            Message = "Don't disable warnings using #pragma warning disable",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
+                                        };
+
+            this.VerifyCSharpDiagnostic(test, expected);
+        }
+
+        [Fact]
+        public void NoErrorsReported()
+        {
+            const string test = @"";
+
+            this.VerifyCSharpDiagnostic(test);
+        }
+
+        [Fact]
+        public void RestoringBannedWarningIsNotAnError()
+        {
+            const string test = @"#pragma warning restore 1234";
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0008",
+                                            Message = "Don't disable warnings using #pragma warning disable",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
+                                        };
+            this.VerifyCSharpDiagnostic(test, expected);
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/FunFair.CodeAnalysis.csproj
+++ b/src/FunFair.CodeAnalysis/FunFair.CodeAnalysis.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- Visual Studio 2019 is incapable of running .net standard 2.1 ! -->
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/FunFair.CodeAnalysis/ProhibitedPragmaDiagnosticsAnalyzercs.cs
+++ b/src/FunFair.CodeAnalysis/ProhibitedPragmaDiagnosticsAnalyzercs.cs
@@ -1,0 +1,93 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FunFair.CodeAnalysis
+{
+    /// <summary>
+    ///     Looks for prohibited methods.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class ProhibitedPragmasDiagnosticsAnalyzer : DiagnosticAnalyzer
+    {
+        private const string CATEGORY = "Illegal Pragmas";
+
+        private static readonly string[] AllowedWarnigns =
+        {
+            // Xml Docs
+            "1591",
+
+            // Nullable Reference types - TODO: FIX THESE
+            "8600",
+
+            // Nullable Reference types - TODO: FIX THESE
+            "8601",
+
+            // Nullable Reference types - TODO: FIX THESE
+            "8602",
+
+            // Nullable Reference types - TODO: FIX THESE
+            "8603",
+
+            // Nullable Reference types - TODO: FIX THESE
+            "8604",
+
+            // Nullable Reference types - TODO: FIX THESE
+            "8618",
+
+            // Nullable Reference types - TODO: FIX THESE
+            "8619",
+
+            // Nullable Reference types - TODO: FIX THESE
+            "8620",
+
+            // Nullable Reference types - TODO: FIX THESE
+            "8622",
+
+            // Nullable Reference types - TODO: FIX THESE
+            "8625",
+
+            // Nullable Reference types - TODO: FIX THESE
+            "8653"
+        };
+
+        private static readonly DiagnosticDescriptor Rule = RuleHelpers.CreateRule(Rules.RuleDontDisableWarnings,
+                                                                                   CATEGORY,
+                                                                                   title: "Don't disable warnings with #pragma warning disable",
+                                                                                   message: "Don't disable warnings using #pragma warning disable");
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => new[] {Rule}.ToImmutableArray();
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterCompilationStartAction(PerformCheck);
+        }
+
+        private static void PerformCheck(CompilationStartAnalysisContext compilationStartContext)
+        {
+            void LookForBannedMethods(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
+            {
+                if (syntaxNodeAnalysisContext.Node is PragmaWarningDirectiveTriviaSyntax pragmaWarningDirective)
+                {
+                    foreach (ExpressionSyntax invocation in pragmaWarningDirective.ErrorCodes)
+                    {
+                        if (!AllowedWarnigns.Contains(invocation.ToString()))
+                        {
+                            syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation()));
+                        }
+                    }
+                }
+            }
+
+            compilationStartContext.RegisterSyntaxNodeAction(LookForBannedMethods, SyntaxKind.PragmaWarningDirectiveTrivia);
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/RuleHelpers.cs
+++ b/src/FunFair.CodeAnalysis/RuleHelpers.cs
@@ -1,0 +1,15 @@
+using Microsoft.CodeAnalysis;
+
+namespace FunFair.CodeAnalysis
+{
+    internal static class RuleHelpers
+    {
+        public static DiagnosticDescriptor CreateRule(string code, string category, string title, string message)
+        {
+            LiteralString translatableTitle = new LiteralString(title);
+            LiteralString translatableMessage = new LiteralString(message);
+
+            return new DiagnosticDescriptor(code, translatableTitle, translatableMessage, category, DiagnosticSeverity.Error, isEnabledByDefault: true, translatableMessage);
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/Rules.cs
+++ b/src/FunFair.CodeAnalysis/Rules.cs
@@ -9,5 +9,6 @@ namespace FunFair.CodeAnalysis
         public const string RuleDontUseDateTimeOffsetUtcNow = @"FFS0005";
         public const string RuleDontUseArbitrarySql = @"FFS0006";
         public const string RuleDontUseArbitrarySqlForQueries = @"FFS0007";
+        public const string RuleDontDisableWarnings = @"FFS0008";
     }
 }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Ban's use of #pragma warning disable for non-whitelisted warnings

Note; at present:

* Not sure on the list of warnings to whitelist
* Can't merge until ALL the code builds with a pre-release version of this 
* Need to work out if can detect unit test assemblies and apply a slightly more relaxed attitude so that things can be tested.

## Related Issue\Feature

<!--- Please link to the issue or feature: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

<!--- Insert Deployment configuration changes here -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes once they are true. -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [x] There are no Resharper\static code analysis errors anywhere in the solution.
- [x] I have run a code clean-up on any files I have modified to make sure they are in the correct format.
- [x] I have added tests to cover my changes.
- [x] All new/modified code has sufficient logging to be able to diagnose what is wrong.
- [x] All new and existing tests passed.
- [x] All new/modified public interfaces/classes have are documented with xmldoc comments.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR
