### PR TITLE
Prohibition of XUnit Assert.True/Assert.False without message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please ADD ALL Changes to the UNRELASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Added
+- FF-1848 - Prohibition of XUnit Assert.True/Assert.False without message
 ### Fixed
 ### Changed
 ### Removed

--- a/src/FunFair.CodeAnalysis.Tests/FunFair.CodeAnalysis.Tests.csproj
+++ b/src/FunFair.CodeAnalysis.Tests/FunFair.CodeAnalysis.Tests.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.20" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/FunFair.CodeAnalysis.Tests/FunFair.CodeAnalysis.Tests.csproj
+++ b/src/FunFair.CodeAnalysis.Tests/FunFair.CodeAnalysis.Tests.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.5.132" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FunFair.CodeAnalysis\FunFair.CodeAnalysis.csproj" />

--- a/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodInvocationsDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodInvocationsDiagnosticsAnalyzerTests.cs
@@ -1,0 +1,168 @@
+using FunFair.CodeAnalysis.Tests.Helpers;
+using FunFair.CodeAnalysis.Tests.Verifiers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace FunFair.CodeAnalysis.Tests
+{
+    public sealed class ProhibitedMethodInvocationsDiagnosticsAnalyzerTests : CodeFixVerifier
+    {
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new ProhibitedMethodInvocationsDiagnosticsAnalyzer();
+        }
+
+        [Fact]
+        public void AssertTrueWithoutMessageIsBanned()
+        {
+            const string test = @"
+    using System;
+
+    namespace XUnit
+    {
+         public class Assert
+         {
+                public static void True(bool condition, string userMessage1)
+                {
+                }
+
+                public static void True(bool condition)
+                {
+                }
+         }
+    }
+
+    namespace ConsoleApplication1
+    {
+
+        class TypeName
+        {
+            void Test()
+            {
+                XUnit.Assert.True(true);
+            }
+        }
+    }";
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0009",
+                                            Message = @"Only use Assert.True with message parameter",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 25, column: 17)}
+                                        };
+
+            this.VerifyCSharpDiagnostic(test, expected);
+        }
+
+        [Fact]
+        public void AssertTrueWithMessageIsAllowed()
+        {
+            const string test = @"
+    using System;
+
+    namespace XUnit
+    {
+         public class Assert
+         {
+                public static void True(bool condition, string userMessage1)
+                {
+                }
+
+                public static void True(bool condition)
+                {
+                }
+         }
+    }
+
+    namespace ConsoleApplication1
+    {
+
+        class TypeName
+        {
+            void Test()
+            {
+                XUnit.Assert.True(true, ""Somevalue"");
+            }
+        }
+    }";
+            this.VerifyCSharpDiagnostic(test);
+        }
+
+        [Fact]
+        public void AssertFalseWithoutMessageIsBanned()
+        {
+            const string test = @"
+    using System;
+
+    namespace XUnit
+    {
+         public class Assert
+         {
+                public static void False(bool condition, string userMessage1)
+                {
+                }
+
+                public static void False(bool condition)
+                {
+                }
+         }
+    }
+
+    namespace ConsoleApplication1
+    {
+
+        class TypeName
+        {
+            void Test()
+            {
+                XUnit.Assert.False(false);
+            }
+        }
+    }";
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0010",
+                                            Message = @"Only use Assert.False with message parameter",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 25, column: 17)}
+                                        };
+
+            this.VerifyCSharpDiagnostic(test, expected);
+        }
+
+        [Fact]
+        public void AssertFalseWithMessageIsAllowed()
+        {
+            const string test = @"
+    using System;
+
+    namespace XUnit
+    {
+         public class Assert
+         {
+                public static void False(bool condition, string userMessage1)
+                {
+                }
+
+                public static void False(bool condition)
+                {
+                }
+         }
+    }
+
+    namespace ConsoleApplication1
+    {
+
+        class TypeName
+        {
+            void Test()
+            {
+                XUnit.Assert.False(false, ""Somevalue"");
+            }
+        }
+    }";
+            this.VerifyCSharpDiagnostic(test);
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodInvocationsDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodInvocationsDiagnosticsAnalyzerTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using FunFair.CodeAnalysis.Tests.Helpers;
 using FunFair.CodeAnalysis.Tests.Verifiers;
 using Microsoft.CodeAnalysis;
@@ -14,7 +15,7 @@ namespace FunFair.CodeAnalysis.Tests
         }
 
         [Fact]
-        public void AssertTrueWithoutMessageIsBanned()
+        public Task AssertTrueWithoutMessageIsBannedAsync()
         {
             const string test = @"
     using System;
@@ -52,11 +53,11 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 25, column: 17)}
                                         };
 
-            this.VerifyCSharpDiagnostic(test, expected);
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
         }
 
         [Fact]
-        public void AssertTrueWithMessageIsAllowed()
+        public Task AssertTrueWithMessageIsAllowedAsync()
         {
             const string test = @"
     using System;
@@ -86,11 +87,11 @@ namespace FunFair.CodeAnalysis.Tests
             }
         }
     }";
-            this.VerifyCSharpDiagnostic(test);
+            return this.VerifyCSharpDiagnosticAsync(test);
         }
 
         [Fact]
-        public void AssertFalseWithoutMessageIsBanned()
+        public Task AssertFalseWithoutMessageIsBannedAsync()
         {
             const string test = @"
     using System;
@@ -128,11 +129,11 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 25, column: 17)}
                                         };
 
-            this.VerifyCSharpDiagnostic(test, expected);
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
         }
 
         [Fact]
-        public void AssertFalseWithMessageIsAllowed()
+        public Task AssertFalseWithMessageIsAllowedAsync()
         {
             const string test = @"
     using System;
@@ -162,7 +163,8 @@ namespace FunFair.CodeAnalysis.Tests
             }
         }
     }";
-            this.VerifyCSharpDiagnostic(test);
+
+            return this.VerifyCSharpDiagnosticAsync(test);
         }
     }
 }

--- a/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodsDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodsDiagnosticsAnalyzerTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using FunFair.CodeAnalysis.Tests.Helpers;
 using FunFair.CodeAnalysis.Tests.Verifiers;
 using Microsoft.CodeAnalysis;
@@ -14,7 +15,7 @@ namespace FunFair.CodeAnalysis.Tests
         }
 
         [Fact]
-        public void DateTimeNowIsBannedInConstructors()
+        public Task DateTimeNowIsBannedInConstructorsAsync()
         {
             const string test = @"
     using System;
@@ -39,11 +40,11 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
                                         };
 
-            this.VerifyCSharpDiagnostic(test, expected);
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
         }
 
         [Fact]
-        public void DateTimeNowIsBannedInConversionOperators()
+        public Task DateTimeNowIsBannedInConversionOperatorsAsync()
         {
             const string test = @"
     using System;
@@ -68,11 +69,11 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
                                         };
 
-            this.VerifyCSharpDiagnostic(test, expected);
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
         }
 
         [Fact]
-        public void DateTimeNowIsBannedInMethods()
+        public Task DateTimeNowIsBannedInMethodsAsync()
         {
             const string test = @"
     using System;
@@ -95,11 +96,11 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 10, column: 28)}
                                         };
 
-            this.VerifyCSharpDiagnostic(test, expected);
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
         }
 
         [Fact]
-        public void DateTimeNowIsBannedInOperators()
+        public Task DateTimeNowIsBannedInOperatorsAsync()
         {
             const string test = @"
     using System;
@@ -124,11 +125,11 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 49)}
                                         };
 
-            this.VerifyCSharpDiagnostic(test, expected);
+            return  this.VerifyCSharpDiagnosticAsync(test, expected);
         }
 
         [Fact]
-        public void DateTimeNowIsBannedInProperties()
+        public Task DateTimeNowIsBannedInPropertiesAsync()
         {
             const string test = @"
     using System;
@@ -154,11 +155,11 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 28)}
                                         };
 
-            this.VerifyCSharpDiagnostic(test, expected);
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
         }
 
         [Fact]
-        public void DateTimeOffsetNowIsBanned()
+        public Task DateTimeOffsetNowIsBannedAsync()
         {
             const string test = @"
     using System;
@@ -181,11 +182,11 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 10, column: 28)}
                                         };
 
-            this.VerifyCSharpDiagnostic(test, expected);
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
         }
 
         [Fact]
-        public void DateTimeOffsetUtcNowIsBanned()
+        public Task DateTimeOffsetUtcNowIsBannedAsync()
         {
             const string test = @"
     using System;
@@ -208,11 +209,11 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 10, column: 28)}
                                         };
 
-            this.VerifyCSharpDiagnostic(test, expected);
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
         }
 
         [Fact]
-        public void DateTimeTodayIsBanned()
+        public Task DateTimeTodayIsBannedAsync()
         {
             const string test = @"
     using System;
@@ -235,11 +236,11 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 10, column: 28)}
                                         };
 
-            this.VerifyCSharpDiagnostic(test, expected);
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
         }
 
         [Fact]
-        public void DateTimeUtcNowIsBanned()
+        public Task DateTimeUtcNowIsBannedAsync()
         {
             const string test = @"
     using System;
@@ -262,11 +263,11 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 10, column: 28)}
                                         };
 
-            this.VerifyCSharpDiagnostic(test, expected);
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
         }
 
         [Fact]
-        public void QueryArbitrarySqlAsyncIsBanned()
+        public Task QueryArbitrarySqlAsyncIsBannedAsync()
         {
             const string test = @"
     using System;
@@ -297,11 +298,11 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 18, column: 17)}
                                         };
 
-            this.VerifyCSharpDiagnostic(test, expected);
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
         }
 
         [Fact]
-        public void ExecuteArbitrarySqlAsyncIsBanned()
+        public Task ExecuteArbitrarySqlAsyncIsBannedAsync()
         {
             const string test = @"
     using System;
@@ -333,15 +334,15 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 19, column: 17)}
                                         };
 
-            this.VerifyCSharpDiagnostic(test, expected);
+           return this.VerifyCSharpDiagnosticAsync(test, expected);
         }
 
         [Fact]
-        public void NoErrorsReported()
+        public Task NoErrorsReportedAsync()
         {
             const string test = @"";
 
-            this.VerifyCSharpDiagnostic(test);
+            return this.VerifyCSharpDiagnosticAsync(test);
         }
     }
 }

--- a/src/FunFair.CodeAnalysis.Tests/ProhibitedPragmasDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ProhibitedPragmasDiagnosticsAnalyzerTests.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using FunFair.CodeAnalysis.Tests.Helpers;
 using FunFair.CodeAnalysis.Tests.Verifiers;
 using Microsoft.CodeAnalysis;
@@ -14,14 +15,15 @@ namespace FunFair.CodeAnalysis.Tests
         }
 
         [Fact]
-        public void AllowedWarningIsNotAnError()
+        public Task AllowedWarningIsNotAnErrorAsync()
         {
             const string test = @"#pragma warning disable 8618";
-            this.VerifyCSharpDiagnostic(test);
+
+            return this.VerifyCSharpDiagnosticAsync(test);
         }
 
         [Fact]
-        public void BannedWarningCannotBeDisabled()
+        public Task BannedWarningCannotBeDisabledAsync()
         {
             const string test = @"#pragma warning disable 1234";
             DiagnosticResult expected = new DiagnosticResult
@@ -32,11 +34,11 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
                                         };
 
-            this.VerifyCSharpDiagnostic(test, expected);
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
         }
 
         [Fact]
-        public void BannedWarningCannotBeDisabledInMethod()
+        public Task BannedWarningCannotBeDisabledInMethodAsync()
         {
             const string test = @"void DoIt()
 {
@@ -53,19 +55,19 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 3, column: 25)}
                                         };
 
-            this.VerifyCSharpDiagnostic(test, expected);
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
         }
 
         [Fact]
-        public void NoErrorsReported()
+        public Task NoErrorsReportedAsync()
         {
             const string test = @"";
 
-            this.VerifyCSharpDiagnostic(test);
+            return this.VerifyCSharpDiagnosticAsync(test);
         }
 
         [Fact]
-        public void RestoringBannedWarningIsNotAnError()
+        public Task RestoringBannedWarningIsNotAnErrorAsync()
         {
             const string test = @"#pragma warning restore 1234";
             DiagnosticResult expected = new DiagnosticResult
@@ -75,7 +77,8 @@ namespace FunFair.CodeAnalysis.Tests
                                             Severity = DiagnosticSeverity.Error,
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
                                         };
-            this.VerifyCSharpDiagnostic(test, expected);
+
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
         }
     }
 }

--- a/src/FunFair.CodeAnalysis.Tests/Verifiers/CodeFixVerifier.Helper.cs
+++ b/src/FunFair.CodeAnalysis.Tests/Verifiers/CodeFixVerifier.Helper.cs
@@ -14,7 +14,7 @@ namespace FunFair.CodeAnalysis.Tests.Verifiers
     ///     Diagnostic Producer class with extra methods dealing with applying codefixes
     ///     All methods are static
     /// </summary>
-    public abstract partial class CodeFixVerifier : DiagnosticVerifier
+    public abstract partial class CodeFixVerifier
     {
         /// <summary>
         ///     Apply the inputted CodeAction to the inputted document.
@@ -23,10 +23,10 @@ namespace FunFair.CodeAnalysis.Tests.Verifiers
         /// <param name="document">The Document to apply the fix on</param>
         /// <param name="codeAction">A CodeAction that will be applied to the Document.</param>
         /// <returns>A Document with the changes from the CodeAction</returns>
-        private static Document ApplyFix(Document document, CodeAction codeAction)
+        private static async System.Threading.Tasks.Task<Document> ApplyFixAsync(Document document, CodeAction codeAction)
         {
-            ImmutableArray<CodeActionOperation> operations = codeAction.GetOperationsAsync(CancellationToken.None)
-                                                                       .Result;
+            ImmutableArray<CodeActionOperation> operations = await codeAction.GetOperationsAsync(CancellationToken.None)
+;
             Solution solution = operations.OfType<ApplyChangesOperation>()
                                           .Single()
                                           .ChangedSolution;
@@ -80,17 +80,16 @@ namespace FunFair.CodeAnalysis.Tests.Verifiers
         /// </summary>
         /// <param name="document">The Document to run the compiler diagnostic analyzers on</param>
         /// <returns>The compiler diagnostics that were found in the code</returns>
-        private static IEnumerable<Diagnostic> GetCompilerDiagnostics(Document document)
+        private static async System.Threading.Tasks.Task<Diagnostic[]> GetCompilerDiagnosticsAsync(Document document)
         {
-            SemanticModel? d = document.GetSemanticModelAsync()
-                                       .Result;
+            SemanticModel? d = await document.GetSemanticModelAsync();
 
             if (d == null)
             {
                 throw new NotNullException();
             }
 
-            return d.GetDiagnostics();
+            return d.GetDiagnostics().ToArray();
         }
 
         /// <summary>
@@ -98,12 +97,11 @@ namespace FunFair.CodeAnalysis.Tests.Verifiers
         /// </summary>
         /// <param name="document">The Document to be converted to a string</param>
         /// <returns>A string containing the syntax of the Document after formatting</returns>
-        private static string GetStringFromDocument(Document document)
+        private static async System.Threading.Tasks.Task<string> GetStringFromDocumentAsync(Document document)
         {
-            Document simplifiedDoc = Simplifier.ReduceAsync(document, Simplifier.Annotation)
-                                               .Result;
-            SyntaxNode? root = simplifiedDoc.GetSyntaxRootAsync()
-                                            .Result;
+            Document simplifiedDoc = await Simplifier.ReduceAsync(document, Simplifier.Annotation)
+;
+            SyntaxNode? root = await simplifiedDoc.GetSyntaxRootAsync();
 
             if (root == null)
             {

--- a/src/FunFair.CodeAnalysis.Tests/Verifiers/DiagnosticVerifier.Helper.cs
+++ b/src/FunFair.CodeAnalysis.Tests/Verifiers/DiagnosticVerifier.Helper.cs
@@ -36,9 +36,9 @@ namespace FunFair.CodeAnalysis.Tests.Verifiers
         /// <param name="language">The language the source classes are in</param>
         /// <param name="analyzer">The analyzer to be run on the sources</param>
         /// <returns>An IEnumerable of Diagnostics that surfaced in the source code, sorted by Location</returns>
-        private static Diagnostic[] GetSortedDiagnostics(string[] sources, string language, DiagnosticAnalyzer analyzer)
+        private static System.Threading.Tasks.Task<Diagnostic[]> GetSortedDiagnosticsAsync(string[] sources, string language, DiagnosticAnalyzer analyzer)
         {
-            return GetSortedDiagnosticsFromDocuments(analyzer, GetDocuments(sources, language));
+            return GetSortedDiagnosticsFromDocumentsAsync(analyzer, GetDocuments(sources, language));
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace FunFair.CodeAnalysis.Tests.Verifiers
         /// <param name="analyzer">The analyzer to run on the documents</param>
         /// <param name="documents">The Documents that the analyzer will be run on</param>
         /// <returns>An IEnumerable of Diagnostics that surfaced in the source code, sorted by Location</returns>
-        protected static Diagnostic[] GetSortedDiagnosticsFromDocuments(DiagnosticAnalyzer analyzer, Document[] documents)
+        protected static async System.Threading.Tasks.Task<Diagnostic[]> GetSortedDiagnosticsFromDocumentsAsync(DiagnosticAnalyzer analyzer, Document[] documents)
         {
             HashSet<Project> projects = new HashSet<Project>();
 
@@ -61,10 +61,8 @@ namespace FunFair.CodeAnalysis.Tests.Verifiers
 
             foreach (Project project in projects)
             {
-                CompilationWithAnalyzers compilationWithAnalyzers = project.GetCompilationAsync()
-                                                                           .Result.WithAnalyzers(ImmutableArray.Create(analyzer));
-                ImmutableArray<Diagnostic> diags = compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync()
-                                                                           .Result;
+                CompilationWithAnalyzers compilationWithAnalyzers = (await project.GetCompilationAsync()).WithAnalyzers(ImmutableArray.Create(analyzer));
+                ImmutableArray<Diagnostic> diags = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
 
                 foreach (Diagnostic diag in diags)
                 {
@@ -77,8 +75,7 @@ namespace FunFair.CodeAnalysis.Tests.Verifiers
                         for (int i = 0; i < documents.Length; i++)
                         {
                             Document document = documents[i];
-                            SyntaxTree? tree = document.GetSyntaxTreeAsync()
-                                                       .Result;
+                            SyntaxTree? tree = await document.GetSyntaxTreeAsync();
 
                             if (tree != null && tree == diag.Location.SourceTree)
                             {

--- a/src/FunFair.CodeAnalysis.Tests/Verifiers/DiagnosticVerifier.cs
+++ b/src/FunFair.CodeAnalysis.Tests/Verifiers/DiagnosticVerifier.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using FunFair.CodeAnalysis.Tests.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -101,7 +102,7 @@ namespace FunFair.CodeAnalysis.Tests.Verifiers
         /// </summary>
         /// <param name="source">A class in the form of a string to run the analyzer on</param>
         /// <param name="expected"> DiagnosticResults that should appear after the analyzer is run on the source</param>
-        protected void VerifyCSharpDiagnostic(string source, params DiagnosticResult[] expected)
+        protected Task VerifyCSharpDiagnosticAsync(string source, params DiagnosticResult[] expected)
         {
             DiagnosticAnalyzer? diagnostic = this.GetCSharpDiagnosticAnalyzer();
 
@@ -110,7 +111,7 @@ namespace FunFair.CodeAnalysis.Tests.Verifiers
                 throw new NotNullException();
             }
 
-            VerifyDiagnostics(new[] {source}, LanguageNames.CSharp, diagnostic, expected);
+            return VerifyDiagnosticsAsync(new[] {source}, LanguageNames.CSharp, diagnostic, expected);
         }
 
         /// <summary>
@@ -119,7 +120,7 @@ namespace FunFair.CodeAnalysis.Tests.Verifiers
         /// </summary>
         /// <param name="sources">An array of strings to create source documents from to run the analyzers on</param>
         /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
-        protected void VerifyCSharpDiagnostic(string[] sources, params DiagnosticResult[] expected)
+        protected Task VerifyCSharpDiagnosticAsync(string[] sources, params DiagnosticResult[] expected)
         {
             DiagnosticAnalyzer? diagnostic = this.GetCSharpDiagnosticAnalyzer();
 
@@ -128,7 +129,7 @@ namespace FunFair.CodeAnalysis.Tests.Verifiers
                 throw new NotNullException();
             }
 
-            VerifyDiagnostics(sources, LanguageNames.CSharp, diagnostic, expected);
+            return VerifyDiagnosticsAsync(sources, LanguageNames.CSharp, diagnostic, expected);
         }
 
         /// <summary>
@@ -139,9 +140,10 @@ namespace FunFair.CodeAnalysis.Tests.Verifiers
         /// <param name="language">The language of the classes represented by the source strings</param>
         /// <param name="analyzer">The analyzer to be run on the source code</param>
         /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
-        private static void VerifyDiagnostics(string[] sources, string language, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expected)
+        private static async Task VerifyDiagnosticsAsync(string[] sources, string language, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expected)
         {
-            Diagnostic[] diagnostics = GetSortedDiagnostics(sources, language, analyzer);
+            Diagnostic[] diagnostics = await GetSortedDiagnosticsAsync(sources, language, analyzer);
+
             VerifyDiagnosticResults(diagnostics, analyzer, expected);
         }
 

--- a/src/FunFair.CodeAnalysis/FunFair.CodeAnalysis.csproj
+++ b/src/FunFair.CodeAnalysis/FunFair.CodeAnalysis.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="AsyncFixer" Version="1.1.6" PrivateAssets="All" />
     <PackageReference Include="DisableDateTimeNow" Version="1.0.5883.39470" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.5.132" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.3.0.14607" PrivateAssets="All" />
     <PackageReference Include="Roslynator.Analyzers" Version="2.3.0" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />

--- a/src/FunFair.CodeAnalysis/FunFair.CodeAnalysis.csproj
+++ b/src/FunFair.CodeAnalysis/FunFair.CodeAnalysis.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="AsyncFixer" Version="1.1.6" PrivateAssets="All" />
     <PackageReference Include="DisableDateTimeNow" Version="1.0.5883.39470" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.5.132" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.5.132" PrivateAssets="All"/>
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.3.0.14607" PrivateAssets="All" />
     <PackageReference Include="Roslynator.Analyzers" Version="2.3.0" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />

--- a/src/FunFair.CodeAnalysis/FunFair.CodeAnalysis.csproj
+++ b/src/FunFair.CodeAnalysis/FunFair.CodeAnalysis.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="DisableDateTimeNow" Version="1.0.5883.39470" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" PrivateAssets="All" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.3.0.14607" PrivateAssets="All" />
-    <PackageReference Include="Roslynator.Analyzers" Version="2.3.0" PrivateAssets="All"/>
+    <PackageReference Include="Roslynator.Analyzers" Version="2.3.0" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FunFair.CodeAnalysis/ProhibitedMethodInvocationsDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ProhibitedMethodInvocationsDiagnosticsAnalyzer.cs
@@ -1,0 +1,176 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FunFair.CodeAnalysis
+{
+    /// <inheritdoc />
+    /// <summary>
+    ///     Looks for prohibited methods with specific parameter invocation
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class ProhibitedMethodInvocationsDiagnosticsAnalyzer : DiagnosticAnalyzer
+    {
+        private const string CATEGORY = "Illegal Method Invocations";
+
+        private static readonly ProhibitedMethodsSpec[] BannedMethods =
+        {
+            new ProhibitedMethodsSpec(Rules.RuleDontUseAssertTrueWithoutMessage,
+                                      title: @"Avoid use of assert method without message",
+                                      message: "Only use Assert.True with message parameter",
+                                      sourceClass: "XUnit.Assert",
+                                      bannedMethod: "True",
+                                      new[] {new[] {"bool"}}),
+            new ProhibitedMethodsSpec(Rules.RuleDontUseAssertFalseWithoutMessage,
+                                      title: @"Avoid use of assert method without message",
+                                      message: "Only use Assert.False with message parameter",
+                                      sourceClass: "XUnit.Assert",
+                                      bannedMethod: "False",
+                                      new[] {new[] {"bool"}})
+        };
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            BannedMethods.Select(selector: r => r.Rule)
+                         .ToImmutableArray();
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterCompilationStartAction(PerformCheck);
+        }
+
+        /// <summary>
+        ///     Perform check over code base
+        /// </summary>
+        /// <param name="compilationStartContext"></param>
+        private static void PerformCheck(CompilationStartAnalysisContext compilationStartContext)
+        {
+            Dictionary<string, IEnumerable<IMethodSymbol>> cachedSymbols = new Dictionary<string, IEnumerable<IMethodSymbol>>();
+
+            foreach (ProhibitedMethodsSpec rule in BannedMethods)
+            {
+                if (cachedSymbols.ContainsKey(rule.QualifiedName))
+                {
+                    continue;
+                }
+
+                IMethodSymbol[] methodSignatures = compilationStartContext.Compilation.GetTypeByMetadataName(rule.SourceClass)
+                                                                          .GetMembers()
+                                                                          .Where(predicate: x => x.Name == rule.BannedMethod)
+                                                                          .OfType<IMethodSymbol>()
+                                                                          .ToArray();
+
+                if (methodSignatures.Length > 0)
+                {
+                    cachedSymbols.Add(key: rule.QualifiedName, value: GetAllowedSignaturesForMethod(methodSignatures, rule.BannedSignatures));
+                }
+            }
+
+            void LookForBannedMethods(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
+            {
+                IEnumerable<InvocationExpressionSyntax> invocations = syntaxNodeAnalysisContext.Node.DescendantNodesAndSelf()
+                                                                                               .OfType<InvocationExpressionSyntax>();
+
+                foreach (InvocationExpressionSyntax invocation in invocations)
+                {
+                    string invokedMethod = invocation.Expression.ToString();
+
+                    MemberAccessExpressionSyntax? memberAccessExpr = invocation.Expression as MemberAccessExpressionSyntax;
+                    IMethodSymbol? memberSymbol = syntaxNodeAnalysisContext.SemanticModel.GetSymbolInfo(memberAccessExpr)
+                                                                          .Symbol as IMethodSymbol;
+
+                    // check if there is at least on rule that correspond to invocation method
+                    if (memberSymbol == null || !cachedSymbols.TryGetValue(invokedMethod, out IEnumerable<IMethodSymbol> allowedMethodSignatures))
+                    {
+                        continue;
+                    }
+
+                    IEnumerable<ProhibitedMethodsSpec> prohibitedMethods = BannedMethods.Where(predicate: rule => rule.QualifiedName == invokedMethod);
+
+                    foreach (ProhibitedMethodsSpec prohibitedMethod in prohibitedMethods)
+                    {
+                        if (!IsInvocationAllowed(memberSymbol, allowedMethodSignatures))
+                        {
+                            syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(prohibitedMethod.Rule, invocation.GetLocation()));
+                        }
+                    }
+                }
+            }
+
+            compilationStartContext.RegisterSyntaxNodeAction(LookForBannedMethods, SyntaxKind.MethodDeclaration);
+        }
+
+        /// <summary>
+        ///     Filter method signatures to get only signatures allowed by rule
+        /// </summary>
+        /// <param name="methodSignatures">All signatures of one method</param>
+        /// <param name="ruleSignatures">All banned signatures</param>
+        /// <returns></returns>
+        private static IEnumerable<IMethodSymbol> GetAllowedSignaturesForMethod(IEnumerable<IMethodSymbol> methodSignatures, IEnumerable<IEnumerable<string>> ruleSignatures)
+        {
+            List<IMethodSymbol> methodSignatureList = methodSignatures.ToList();
+
+            foreach (IEnumerable<string> ruleSignature in ruleSignatures)
+            {
+                methodSignatureList.RemoveAll(match: methodSymbol => methodSymbol.Parameters.Select(selector: parameterSymbol => parameterSymbol.Type.ToString())
+                                                                                 .SequenceEqual(ruleSignature));
+            }
+
+            return methodSignatureList;
+        }
+
+        /// <summary>
+        ///     Check if invoked method signature is in list of allowed signatures
+        /// </summary>
+        /// <param name="invocationArguments">Arguments used in invocation of method</param>
+        /// <param name="methodSignatures">List of all valid signatures for method</param>
+        /// <returns></returns>
+        private static bool IsInvocationAllowed(IMethodSymbol invocationArguments, IEnumerable<IMethodSymbol> methodSignatures)
+        {
+            return methodSignatures.Any(predicate: methodSignature => methodSignature.Parameters.SequenceEqual(invocationArguments.Parameters));
+        }
+
+        private sealed class ProhibitedMethodsSpec
+        {
+            public ProhibitedMethodsSpec(string ruleId, string title, string message, string sourceClass, string bannedMethod, IEnumerable<IEnumerable<string>> bannedSignatures)
+            {
+                this.SourceClass = sourceClass;
+                this.BannedMethod = bannedMethod;
+                this.Rule = CreateRule(ruleId, title, message);
+                this.BannedSignatures = bannedSignatures;
+            }
+
+            public string SourceClass { get; }
+
+            public string BannedMethod { get; }
+
+            /// <summary>
+            ///     List of all method signatures that are banned, every signature is given with array of types in exact parameter order
+            /// </summary>
+            public IEnumerable<IEnumerable<string>> BannedSignatures { get; }
+
+            public DiagnosticDescriptor Rule { get; }
+
+            private static DiagnosticDescriptor CreateRule(string code, string title, string message)
+            {
+                LiteralString translatableTitle = new LiteralString(title);
+                LiteralString translatableMessage = new LiteralString(message);
+
+                return new DiagnosticDescriptor(code, translatableTitle, translatableMessage, CATEGORY, DiagnosticSeverity.Error, isEnabledByDefault: true, translatableMessage);
+            }
+
+            /// <summary>
+            ///     Full qualified name of method
+            /// </summary>
+            public string QualifiedName => $"{this.SourceClass}.{this.BannedMethod}";
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/Rules.cs
+++ b/src/FunFair.CodeAnalysis/Rules.cs
@@ -10,5 +10,7 @@ namespace FunFair.CodeAnalysis
         public const string RuleDontUseArbitrarySql = @"FFS0006";
         public const string RuleDontUseArbitrarySqlForQueries = @"FFS0007";
         public const string RuleDontDisableWarnings = @"FFS0008";
+        public const string RuleDontUseAssertTrueWithoutMessage = @"FFS0009";
+        public const string RuleDontUseAssertFalseWithoutMessage = @"FFS0010";
     }
 }


### PR DESCRIPTION
# PR Details

- FF-1848 - Prohibition of XUnit Assert.True/Assert.False without message

## Description

<!--- Describe your changes in detail -->

## Related Issue\Feature

<!--- Please link to the issue or feature: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

<!--- Insert Deployment configuration changes here -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes once they are true. -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] There are no Resharper\static code analysis errors anywhere in the solution.
- [ ] I have run a code clean-up on any files I have modified to make sure they are in the correct format.
- [x] I have added tests to cover my changes.
- [x] All new/modified code has sufficient logging to be able to diagnose what is wrong.
- [x] All new and existing tests passed.
- [ ] All new/modified public interfaces/classes have are documented with xmldoc comments.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR
