### PR TITLE
[FF-2141] Fix QueryArbitarySql not being picked up as banned

### DIFF
--- a/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodsDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodsDiagnosticsAnalyzerTests.cs
@@ -267,41 +267,6 @@ namespace FunFair.CodeAnalysis.Tests
         }
 
         [Fact]
-        public Task QueryArbitrarySqlAsyncIsBannedAsync()
-        {
-            const string test = @"
-    using System;
-
-    namespace FunFair.Common.Data
-    {
-         public interface ISqlServerDatabase
-         {
-                Task QueryArbitrarySqlAsync(string sql);
-         }
-    }
-
-    namespace ConsoleApplication1
-    {
-        class TypeName
-        {
-            void Test(FunFair.Common.Data.ISqlServerDatabase sqlServerDatabase, string sql)
-            {
-                sqlServerDatabase.QueryArbitrarySqlAsync(sql)
-            }
-        }
-    }";
-            DiagnosticResult expected = new DiagnosticResult
-                                        {
-                                            Id = "FFS0007",
-                                            Message = @"Only use ISqlServerDatabase.QueryArbitrarySqlAsync in integration tests",
-                                            Severity = DiagnosticSeverity.Error,
-                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 18, column: 17)}
-                                        };
-
-            return this.VerifyCSharpDiagnosticAsync(test, expected);
-        }
-
-        [Fact]
         public Task ExecuteArbitrarySqlAsyncIsBannedAsync()
         {
             const string test = @"
@@ -343,6 +308,81 @@ namespace FunFair.CodeAnalysis.Tests
             const string test = @"";
 
             return this.VerifyCSharpDiagnosticAsync(test);
+        }
+
+        [Fact]
+        public Task QueryArbitrarySqlAsyncGenericIsBannedAsync()
+        {
+            const string test = @"
+    using System;
+
+    namespace FunFair.Common.Data
+    {
+         public interface ISqlServerDatabase
+         {
+                Task QueryArbitrarySqlAsync<T>(string sql);
+         }
+    }
+
+    namespace ConsoleApplication1
+    {
+        class Test
+        {
+            public int Id { get; set; }
+        }
+
+        class TypeName
+        {
+            void Test(FunFair.Common.Data.ISqlServerDatabase sqlServerDatabase, string sql)
+            {
+                sqlServerDatabase.QueryArbitrarySqlAsync<Test>(sql)
+            }
+        }
+    }";
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0007",
+                                            Message = @"Only use ISqlServerDatabase.QueryArbitrarySqlAsync in integration tests",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 18, column: 17)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
+        }
+
+        [Fact]
+        public Task QueryArbitrarySqlAsyncIsBannedAsync()
+        {
+            const string test = @"
+    using System;
+
+    namespace FunFair.Common.Data
+    {
+         public interface ISqlServerDatabase
+         {
+                Task QueryArbitrarySqlAsync(string sql);
+         }
+    }
+
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            void Test(FunFair.Common.Data.ISqlServerDatabase sqlServerDatabase, string sql)
+            {
+                sqlServerDatabase.QueryArbitrarySqlAsync(sql)
+            }
+        }
+    }";
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0007",
+                                            Message = @"Only use ISqlServerDatabase.QueryArbitrarySqlAsync in integration tests",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 18, column: 17)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
         }
     }
 }

--- a/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodsDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodsDiagnosticsAnalyzerTests.cs
@@ -125,7 +125,7 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 49)}
                                         };
 
-            return  this.VerifyCSharpDiagnosticAsync(test, expected);
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
         }
 
         [Fact]
@@ -299,7 +299,7 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 19, column: 17)}
                                         };
 
-           return this.VerifyCSharpDiagnosticAsync(test, expected);
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
         }
 
         [Fact]
@@ -344,7 +344,7 @@ namespace FunFair.CodeAnalysis.Tests
                                             Id = "FFS0007",
                                             Message = @"Only use ISqlServerDatabase.QueryArbitrarySqlAsync in integration tests",
                                             Severity = DiagnosticSeverity.Error,
-                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 18, column: 17)}
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 23, column: 17)}
                                         };
 
             return this.VerifyCSharpDiagnosticAsync(test, expected);

--- a/src/FunFair.CodeAnalysis.sln
+++ b/src/FunFair.CodeAnalysis.sln
@@ -9,6 +9,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FunFair.CodeAnalysis", "Fun
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FunFair.CodeAnalysis.Tests", "FunFair.CodeAnalysis.Tests\FunFair.CodeAnalysis.Tests.csproj", "{2395F045-1603-4CB3-A0F7-BD3FCFC0006D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Config", "Config", "{873377A7-1525-4BC8-97B5-7BE62D6994EB}"
+ProjectSection(SolutionItems) = preProject
+	CodeAnalysis.ruleset = CodeAnalysis.ruleset
+	global.json = global.json
+EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/FunFair.CodeAnalysis/ProhibitedMethodsDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ProhibitedMethodsDiagnosticsAnalyzer.cs
@@ -111,7 +111,7 @@ namespace FunFair.CodeAnalysis
                 {
                     if (StringComparer.OrdinalIgnoreCase.Equals(typeInfo.ConstructedFrom.MetadataName, metadataType.MetadataName))
                     {
-                        if (invocation.Name.ToString() == item.BannedMethod)
+                        if (invocation.Name.Identifier.ToString() == item.BannedMethod)
                         {
                             syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(item.Rule, invocation.GetLocation()));
                         }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
When developing FF-2141 spotted that a banned method wan't picked up as being banned.

## Related Issue\Feature

<!--- Please link to the issue or feature: -->
https://funfairtech.atlassian.net/browse/FF-2141

## How Has This Been Tested

- [x] All unit tests pass.
- [x] All integration tests pass.
- [x] Manual Testing: 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Steeped through in debugger with test cases.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [x] Additional Unit Tests\Integration Tests
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

<!--- Insert Deployment configuration changes here -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes once they are true. -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [x] There are no Resharper\static code analysis errors anywhere in the solution.
- [x] I have run a code clean-up on any files I have modified to make sure they are in the correct format.
- [x] I have added tests to cover my changes.
- [x] I have run the code and quickly verified it all works to my satisfaction.
- [x] All new/modified code has sufficient logging to be able to diagnose what is wrong.
- [x] All new and existing tests passed.
- [x] All new/modified public interfaces/classes have are documented with xmldoc comments.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.
