### PR TITLE
Added checks for structs that are not marked as read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please ADD ALL Changes to the UNRELASED SECTION and not a specific release
 ## [Unreleased]
 ### Added
 - Checks for structs that are not marked as read-only.
+- Checks for classes that are not marked as static, sealed or abstract.
 ### Fixed
 ### Changed
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please ADD ALL Changes to the UNRELASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Added
+- Checks for structs that are not marked as read-only.
 ### Fixed
 ### Changed
 ### Removed

--- a/src/FunFair.CodeAnalysis.Tests/ClassAnalysisDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ClassAnalysisDiagnosticsAnalyzerTests.cs
@@ -1,0 +1,56 @@
+﻿using System.Threading.Tasks;
+using FunFair.CodeAnalysis.Tests.Helpers;
+using FunFair.CodeAnalysis.Tests.Verifiers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace FunFair.CodeAnalysis.Tests
+{
+    public sealed class ClassAnalysisDiagnosticsAnalyzerTests : CodeFixVerifier
+    {
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new ClassAnalysisDiagnosticsAnalyzer();
+        }
+
+        [Fact]
+        public Task AbstractClassNotAnErrorAsync()
+        {
+            const string test = @"public abstract class Test {}";
+
+            return this.VerifyCSharpDiagnosticAsync(test);
+        }
+
+        [Fact]
+        public Task ClassWithNoModifiersIsAnErrorAsync()
+        {
+            const string test = @"public class Test {}";
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0012",
+                                            Message = "Classes should be static, sealed or abstract",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
+        }
+
+        [Fact]
+        public Task SealedClassNotAnErrorAsync()
+        {
+            const string test = @"public sealed class Test {}";
+
+            return this.VerifyCSharpDiagnosticAsync(test);
+        }
+
+        [Fact]
+        public Task StaticClassNotAnErrorAsync()
+        {
+            const string test = @"public static class Test {}";
+
+            return this.VerifyCSharpDiagnosticAsync(test);
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis.Tests/StructAnalysisDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/StructAnalysisDiagnosticsAnalyzerTests.cs
@@ -1,0 +1,40 @@
+﻿using System.Threading.Tasks;
+using FunFair.CodeAnalysis.Tests.Helpers;
+using FunFair.CodeAnalysis.Tests.Verifiers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace FunFair.CodeAnalysis.Tests
+{
+    public sealed class StructAnalysisDiagnosticsAnalyzerTests : CodeFixVerifier
+    {
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new StructAnalysisDiagnosticsAnalyzer();
+        }
+
+        [Fact]
+        public Task NonReadOnlyStructIsAnErrorAsync()
+        {
+            const string test = @"public struct Test {}";
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0011",
+                                            Message = "Structs should be read-only",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(test, expected);
+        }
+
+        [Fact]
+        public Task ReadOnlyStructNotAnErrorAsync()
+        {
+            const string test = @"public readonly struct Test {}";
+
+            return this.VerifyCSharpDiagnosticAsync(test);
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/ClassAnalysisDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ClassAnalysisDiagnosticsAnalyzer.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FunFair.CodeAnalysis
+{
+    /// <summary>
+    ///     Looks for issue with class declarations
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class ClassAnalysisDiagnosticsAnalyzer : DiagnosticAnalyzer
+    {
+        private const string CATEGORY = "Classes";
+
+        private static readonly DiagnosticDescriptor Rule = RuleHelpers.CreateRule(Rules.RuleClassesShouldBeStaticSealedOrAbstract,
+                                                                                   CATEGORY,
+                                                                                   title: "Classes should be static, sealed or abstract",
+                                                                                   message: "Classes should be static, sealed or abstract");
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => new[] {Rule}.ToImmutableArray();
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterCompilationStartAction(PerformCheck);
+        }
+
+        private static void PerformCheck(CompilationStartAnalysisContext compilationStartContext)
+        {
+            compilationStartContext.RegisterSyntaxNodeAction(MustBeReadOnly, SyntaxKind.ClassDeclaration);
+        }
+
+        private static void MustBeReadOnly(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
+        {
+            if (!(syntaxNodeAnalysisContext.Node is ClassDeclarationSyntax classDeclarationSyntax))
+            {
+                return;
+            }
+
+            if (!classDeclarationSyntax.Modifiers.Any(IsWhiteListedClassModifier))
+            {
+                syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(Rule, classDeclarationSyntax.GetLocation()));
+            }
+        }
+
+        private static bool IsWhiteListedClassModifier(SyntaxToken syntaxToken)
+        {
+            SyntaxKind kind = syntaxToken.Kind();
+
+            return kind == SyntaxKind.StaticKeyword || kind == SyntaxKind.AbstractKeyword || kind == SyntaxKind.SealedKeyword;
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/Rules.cs
+++ b/src/FunFair.CodeAnalysis/Rules.cs
@@ -12,5 +12,6 @@ namespace FunFair.CodeAnalysis
         public const string RuleDontDisableWarnings = @"FFS0008";
         public const string RuleDontUseAssertTrueWithoutMessage = @"FFS0009";
         public const string RuleDontUseAssertFalseWithoutMessage = @"FFS0010";
+        public const string RuleStructsShouldBeReadOnly = @"FFS0011";
     }
 }

--- a/src/FunFair.CodeAnalysis/Rules.cs
+++ b/src/FunFair.CodeAnalysis/Rules.cs
@@ -13,5 +13,6 @@ namespace FunFair.CodeAnalysis
         public const string RuleDontUseAssertTrueWithoutMessage = @"FFS0009";
         public const string RuleDontUseAssertFalseWithoutMessage = @"FFS0010";
         public const string RuleStructsShouldBeReadOnly = @"FFS0011";
+        public const string RuleClassesShouldBeStaticSealedOrAbstract = @"FFS0012";
     }
 }

--- a/src/FunFair.CodeAnalysis/StructAnalysisDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/StructAnalysisDiagnosticsAnalyzer.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FunFair.CodeAnalysis
+{
+    /// <summary>
+    ///     Looks for prohibited methods.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class StructAnalysisDiagnosticsAnalyzer : DiagnosticAnalyzer
+    {
+        private const string CATEGORY = "Structs";
+
+        private static readonly DiagnosticDescriptor Rule = RuleHelpers.CreateRule(Rules.RuleStructsShouldBeReadOnly,
+                                                                                   CATEGORY,
+                                                                                   title: "Structs should be read-only",
+                                                                                   message: "Structs should be read-only");
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => new[] {Rule}.ToImmutableArray();
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterCompilationStartAction(PerformCheck);
+        }
+
+        private static void PerformCheck(CompilationStartAnalysisContext compilationStartContext)
+        {
+            compilationStartContext.RegisterSyntaxNodeAction(MustBeReadOnly, SyntaxKind.StructDeclaration);
+        }
+
+        private static void MustBeReadOnly(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
+        {
+            if (!(syntaxNodeAnalysisContext.Node is StructDeclarationSyntax structDeclarationSyntax))
+            {
+                return;
+            }
+
+            if (!structDeclarationSyntax.Modifiers.Any(IsReadOnlyKeyword))
+            {
+                syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(Rule, structDeclarationSyntax.GetLocation()));
+            }
+        }
+
+        private static bool IsReadOnlyKeyword(SyntaxToken syntaxToken)
+        {
+            return syntaxToken.Kind() == SyntaxKind.ReadOnlyKeyword;
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Checks for declaration of structs that aren't marked as readonly

## Related Issue\Feature

<!--- Please link to the issue or feature: -->
FF-1429

## How Has This Been Tested

- [x] All unit tests pass.
- [x] All integration tests pass.
- [ ] Manual Testing: 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

<!--- Insert Deployment configuration changes here -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes once they are true. -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [x] There are no Resharper\static code analysis errors anywhere in the solution.
- [x] I have run a code clean-up on any files I have modified to make sure they are in the correct format.
- [x] I have added tests to cover my changes.
- [x] I have run the code and quickly verified it all works to my satisfaction.
- [x] All new/modified code has sufficient logging to be able to diagnose what is wrong.
- [x] All new and existing tests passed.
- [x] All new/modified public interfaces/classes have are documented with xmldoc comments.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.
