### PR TITLE
[FF-2590] - Explicit checks for ArgumentExceptions that the failing argument is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please ADD ALL Changes to the UNRELASED SECTION and not a specific release
 ## [Unreleased]
 ### Added
 - FF-2413 - JsonSerializer serialize and deserialize rules
+- FF-2590 - Explicit checks for ArgumentExceptions that they have the parameter name passed
 ### Fixed
 ### Changed
 - FF-1429 - Updated SonarAnalyzer.CSharp to 8.9.0.19135

--- a/src/FunFair.CodeAnalysis.Tests/ArgumentExceptionAnalysisDiagnosticsAnalyzerTest.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ArgumentExceptionAnalysisDiagnosticsAnalyzerTest.cs
@@ -30,10 +30,10 @@ public sealed class Test {
 
             DiagnosticResult expected = new DiagnosticResult
                                         {
-                                            Id = "FFS0012",
-                                            Message = "Classes should be static, sealed or abstract",
+                                            Id = "FFS0016",
+                                            Message = "Argument Exceptions should pass parameter name",
                                             Severity = DiagnosticSeverity.Error,
-                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 8, column: 17)}
                                         };
 
             return this.VerifyCSharpDiagnosticAsync(source: test, expected);
@@ -55,10 +55,10 @@ public sealed class Test {
 
             DiagnosticResult expected = new DiagnosticResult
                                         {
-                                            Id = "FFS0012",
-                                            Message = "Classes should be static, sealed or abstract",
+                                            Id = "FFS0016",
+                                            Message = "Argument Exceptions should pass parameter name",
                                             Severity = DiagnosticSeverity.Error,
-                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 8, column: 17)}
                                         };
 
             return this.VerifyCSharpDiagnosticAsync(source: test, expected);
@@ -116,10 +116,10 @@ public sealed class Test {
 
             DiagnosticResult expected = new DiagnosticResult
                                         {
-                                            Id = "FFS0012",
-                                            Message = "Classes should be static, sealed or abstract",
+                                            Id = "FFS0016",
+                                            Message = "Argument Exceptions should pass parameter name",
                                             Severity = DiagnosticSeverity.Error,
-                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 8, column: 17)}
                                         };
 
             return this.VerifyCSharpDiagnosticAsync(source: test, expected);
@@ -141,10 +141,10 @@ public sealed class Test {
 
             DiagnosticResult expected = new DiagnosticResult
                                         {
-                                            Id = "FFS0012",
-                                            Message = "Classes should be static, sealed or abstract",
+                                            Id = "FFS0016",
+                                            Message = "Argument Exceptions should pass parameter name",
                                             Severity = DiagnosticSeverity.Error,
-                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 8, column: 17)}
                                         };
 
             return this.VerifyCSharpDiagnosticAsync(source: test, expected);
@@ -202,10 +202,10 @@ public sealed class Test {
 
             DiagnosticResult expected = new DiagnosticResult
                                         {
-                                            Id = "FFS0012",
-                                            Message = "Classes should be static, sealed or abstract",
+                                            Id = "FFS0016",
+                                            Message = "Argument Exceptions should pass parameter name",
                                             Severity = DiagnosticSeverity.Error,
-                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 8, column: 17)}
                                         };
 
             return this.VerifyCSharpDiagnosticAsync(source: test, expected);
@@ -227,10 +227,10 @@ public sealed class Test {
 
             DiagnosticResult expected = new DiagnosticResult
                                         {
-                                            Id = "FFS0012",
-                                            Message = "Classes should be static, sealed or abstract",
+                                            Id = "FFS0016",
+                                            Message = "Argument Exceptions should pass parameter name",
                                             Severity = DiagnosticSeverity.Error,
-                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 8, column: 17)}
                                         };
 
             return this.VerifyCSharpDiagnosticAsync(source: test, expected);

--- a/src/FunFair.CodeAnalysis.Tests/ArgumentExceptionAnalysisDiagnosticsAnalyzerTest.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ArgumentExceptionAnalysisDiagnosticsAnalyzerTest.cs
@@ -1,0 +1,290 @@
+﻿using System.Threading.Tasks;
+using FunFair.CodeAnalysis.Tests.Helpers;
+using FunFair.CodeAnalysis.Tests.Verifiers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace FunFair.CodeAnalysis.Tests
+{
+    public sealed class ArgumentExceptionAnalysisDiagnosticsAnalyzerTest : CodeFixVerifier
+    {
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new ArgumentExceptionAnalysisDiagnosticsAnalyzer();
+        }
+
+        [Fact]
+        public Task ArgumentExceptionWhenParameterLessConstructorUsedCausesErrorAsync()
+        {
+            const string test = @"
+using System;
+
+public sealed class Test {
+
+    public void DoIt(string value)
+    {
+        var x = new ArgumentException();
+    }
+}";
+
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0012",
+                                            Message = "Classes should be static, sealed or abstract",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, expected);
+        }
+
+        [Fact]
+        public Task ArgumentExceptionWhenParameterNameNotPassedCausesErrorAsync()
+        {
+            const string test = @"
+using System;
+
+public sealed class Test {
+
+    public void DoIt(string value)
+    {
+        var x = new ArgumentException(""Hello World"");
+    }
+}";
+
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0012",
+                                            Message = "Classes should be static, sealed or abstract",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, expected);
+        }
+
+        [Fact]
+        public Task ArgumentExceptionWhenParameterNamePassedByNameOfIsValidAsync()
+        {
+            const string test = @"
+using System;
+
+public sealed class Test {
+
+    public void DoIt(string value)
+    {
+        var x = new ArgumentException(""Hello World"", nameof(value));
+        
+    }
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test);
+        }
+
+        [Fact]
+        public Task ArgumentExceptionWhenParameterNamePassedByStringIsValidAsync()
+        {
+            const string test = @"
+using System;
+
+public sealed class Test {
+
+    public void DoIt(string value)
+    {
+        var x = new ArgumentException(""Hello World"", ""value"");
+        
+    }
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test);
+        }
+
+        [Fact]
+        public Task ArgumentNullExceptionWhenParameterLessConstructorUsedCausesErrorAsync()
+        {
+            const string test = @"
+using System;
+
+public sealed class Test {
+
+    public void DoIt(string value)
+    {
+        var x = new ArgumentNullException();
+    }
+}";
+
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0012",
+                                            Message = "Classes should be static, sealed or abstract",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, expected);
+        }
+
+        [Fact]
+        public Task ArgumentNullExceptionWhenParameterNameNotPassedCausesErrorAsync()
+        {
+            const string test = @"
+using System;
+
+public sealed class Test {
+
+    public void DoIt(string value)
+    {
+        var x = new ArgumentNullException(""Hello World"", new Exception());
+    }
+}";
+
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0012",
+                                            Message = "Classes should be static, sealed or abstract",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, expected);
+        }
+
+        [Fact]
+        public Task ArgumentNullExceptionWhenParameterNamePassedByNameOfIsValidAsync()
+        {
+            const string test = @"
+using System;
+
+public sealed class Test {
+
+    public void DoIt(string value)
+    {
+        var x = new ArgumentNUllException(""Hello World"", nameof(value));
+        
+    }
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test);
+        }
+
+        [Fact]
+        public Task ArgumentNullExceptionWhenParameterNamePassedByStringIsValidAsync()
+        {
+            const string test = @"
+using System;
+
+public sealed class Test {
+
+    public void DoIt(string value)
+    {
+        var x = new ArgumentNullException(""Hello World"", ""value"");
+        
+    }
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test);
+        }
+
+        [Fact]
+        public Task ArgumentOutOfRangeExceptionWhenParameterLessConstructorUsedCausesErrorAsync()
+        {
+            const string test = @"
+using System;
+
+public sealed class Test {
+
+    public void DoIt(string value)
+    {
+        var x = new ArgumentOutOfRangeException();
+    }
+}";
+
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0012",
+                                            Message = "Classes should be static, sealed or abstract",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, expected);
+        }
+
+        [Fact]
+        public Task ArgumentOutOfRangeExceptionWhenParameterNameNotPassedCausesErrorAsync()
+        {
+            const string test = @"
+using System;
+
+public sealed class Test {
+
+    public void DoIt(string value)
+    {
+        var x = new ArgumentOutOfRangeException(""Hello World"", new Exception());
+    }
+}";
+
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0012",
+                                            Message = "Classes should be static, sealed or abstract",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 25)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, expected);
+        }
+
+        [Fact]
+        public Task ArgumentOutOfRangeExceptionWhenParameterNamePassedByNameOfIsValidAsync()
+        {
+            const string test = @"
+using System;
+
+public sealed class Test {
+
+    public void DoIt(string value)
+    {
+        var x = new ArgumentOutOfRangeException(""Hello World"", nameof(value));
+        
+    }
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test);
+        }
+
+        [Fact]
+        public Task ArgumentOutOfRangeExceptionWhenParameterNamePassedByStringIsValidAsync()
+        {
+            const string test = @"
+using System;
+
+public sealed class Test {
+
+    public void DoIt(string value)
+    {
+        var x = new ArgumentOutOfRangeException(""Hello World"", ""value"");
+        
+    }
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test);
+        }
+
+        [Fact]
+        public Task DoesNotTriggerOnNonExceptionsAsync()
+        {
+            const string test = @"
+public sealed class Test {
+
+    public void DoIt(string value)
+    {
+        var x = new String(nameof(value));
+    }
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test);
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/ArgumentExceptionAnalysisDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ArgumentExceptionAnalysisDiagnosticsAnalyzer.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FunFair.CodeAnalysis
+{
+    /// <summary>
+    ///     Looks for issues with argument exception creation
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class ArgumentExceptionAnalysisDiagnosticsAnalyzer : DiagnosticAnalyzer
+    {
+        private const string CATEGORY = "Exceptions";
+
+        private static readonly DiagnosticDescriptor Rule = RuleHelpers.CreateRule(code: Rules.RuleMustPassParameterNameToArgumentExceptions,
+                                                                                   category: CATEGORY,
+                                                                                   title: "Argument Exceptions should pass parameter name",
+                                                                                   message: "Argument Exceptions should pass parameter name");
+
+        private static readonly string[] ArgumentExceptions = {"System.ArgumentException", "System.ArgumentNullException", "System.ArgumentOutOfRangeException"};
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => new[] {Rule}.ToImmutableArray();
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterCompilationStartAction(PerformCheck);
+        }
+
+        private static void PerformCheck(CompilationStartAnalysisContext compilationStartContext)
+        {
+            compilationStartContext.RegisterSyntaxNodeAction(action: ArgumentExceptionsMustPassParameterName, SyntaxKind.ObjectCreationExpression);
+        }
+
+        private static void ArgumentExceptionsMustPassParameterName(SyntaxNodeAnalysisContext syntaxNodeContext)
+        {
+            if (syntaxNodeContext.Node is ObjectCreationExpressionSyntax objectCreation)
+            {
+                SymbolInfo symbolInfo = syntaxNodeContext.SemanticModel.GetSymbolInfo(objectCreation);
+
+                if (symbolInfo.Symbol is IMethodSymbol methodSymbol)
+                {
+                    if (IsArgumentException(methodSymbol.ReceiverType))
+                    {
+                        IParameterSymbol? parameterNameParameter = methodSymbol.Parameters.FirstOrDefault(parameter => parameter.Name == "paramName");
+
+                        if (parameterNameParameter == null)
+                        {
+                            syntaxNodeContext.ReportDiagnostic(Diagnostic.Create(descriptor: Rule, objectCreation.GetLocation()));
+                        }
+                    }
+                }
+            }
+        }
+
+        private static bool IsArgumentException(ITypeSymbol? methodSymbolReceiverType)
+        {
+            if (methodSymbolReceiverType == null)
+            {
+                return false;
+            }
+
+            string typeName = methodSymbolReceiverType.ToString();
+
+            return ArgumentExceptions.Contains(typeName);
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/Rules.cs
+++ b/src/FunFair.CodeAnalysis/Rules.cs
@@ -17,5 +17,6 @@ namespace FunFair.CodeAnalysis
         public const string RuleTestClassesShouldBeStaticSealedOrAbstractDerivedFromTestBase = @"FFS0013";
         public const string RuleDontUseJsonSerializerWithoutJsonOptions = @"FFS0014";
         public const string RuleDontUseJsonDeserializerWithoutJsonOptions = @"FFS0015";
+        public const string RuleMustPassParameterNameToArgumentExceptions = @"FFS0016";
     }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Makes sure that when an argument Exception (and derived) that the paramName parameter is specified.

## Related Issue\Feature

<!--- Please link to the issue or feature: -->
FF-2590

## How Has This Been Tested

- [ ] All unit tests pass.
- [ ] All integration tests pass.
- [ ] Manual Testing: 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [x] Additional Unit Tests\Integration Tests
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

<!--- Insert Deployment configuration changes here -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes once they are true. -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [x] There are no Resharper\static code analysis errors anywhere in the solution.
- [x] I have run a code clean-up on any files I have modified to make sure they are in the correct format.
- [x] I have added tests to cover my changes.
- [x] I have run the code and quickly verified it all works to my satisfaction.
- [x] All new/modified code has sufficient logging to be able to diagnose what is wrong.
- [x] All new and existing tests passed.
- [x] All new/modified public interfaces/classes have are documented with xmldoc comments.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.
