### PR TITLE
[FF-2591] - Ensure that re-thrown exceptions as another type don't lose the context of the original exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please ADD ALL Changes to the UNRELASED SECTION and not a specific release
 ### Added
 - FF-2413 - JsonSerializer serialize and deserialize rules
 - FF-2590 - Explicit checks for ArgumentExceptions that they have the parameter name passed
+- FF-2591 - Re-Throwing Exception as new exception should pass inner exception
 ### Fixed
 ### Changed
 - FF-1429 - Updated SonarAnalyzer.CSharp to 8.9.0.19135

--- a/src/FunFair.CodeAnalysis.Tests/ReThrowingExceptionShouldSpecifyInnerExceptionDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ReThrowingExceptionShouldSpecifyInnerExceptionDiagnosticsAnalyzerTests.cs
@@ -1,0 +1,6 @@
+﻿namespace FunFair.CodeAnalysis.Tests
+{
+    public class ReThrowingExceptionShouldSpecifyInnerExceptionDiagnosticsAnalyzerTests
+    {
+    }
+}

--- a/src/FunFair.CodeAnalysis.Tests/ReThrowingExceptionShouldSpecifyInnerExceptionDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ReThrowingExceptionShouldSpecifyInnerExceptionDiagnosticsAnalyzerTests.cs
@@ -1,6 +1,105 @@
-﻿namespace FunFair.CodeAnalysis.Tests
+﻿using System.Threading.Tasks;
+using FunFair.CodeAnalysis.Tests.Helpers;
+using FunFair.CodeAnalysis.Tests.Verifiers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace FunFair.CodeAnalysis.Tests
 {
-    public class ReThrowingExceptionShouldSpecifyInnerExceptionDiagnosticsAnalyzerTests
+    public sealed class ReThrowingExceptionShouldSpecifyInnerExceptionDiagnosticsAnalyzerTests : CodeFixVerifier
     {
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new ReThrowingExceptionShouldSpecifyInnerExceptionDiagnosticsAnalyzer();
+        }
+
+        [Fact]
+        public Task ReThrowingExceptionShouldNotTriggerErrorAsync()
+        {
+            const string test = @"
+using System;
+
+public sealed class Test {
+
+    public void DoIt()
+    {
+        try
+        {
+        }
+        catch(Exception exception)
+        {
+            Console.WriteLine(exception.Message);
+            throw;
+        }
+    }
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test);
+        }
+
+        [Fact]
+        public Task ThrowingNewExceptionPassingInnerExceptionShouldNotBeAnErrorAsync()
+        {
+            const string test = @"
+using System;
+
+public sealed class Test {
+
+    public void DoIt()
+    {
+        try
+        {
+        }
+        catch(Exception exception)
+        {
+            Console.WriteLine(exception.Message);
+            throw new NotImplementedException(""Not Implemented yet"", exception);
+        }
+    }
+}";
+
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0017",
+                                            Message = "Provide 'exception' as a inner exception when throw from the catch clauses",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 14, column: 19)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, expected);
+        }
+
+        [Fact]
+        public Task ThrowingNewExceptionWithoutPassingInnerExceptionShouldBeAnErrorAsync()
+        {
+            const string test = @"
+using System;
+
+public sealed class Test {
+
+    public void DoIt()
+    {
+        try
+        {
+        }
+        catch(Exception failingException)
+        {
+            Console.WriteLine(exception.Message);
+            throw new NotImplementedException();
+        }
+    }
+}";
+
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0017",
+                                            Message = "Provide 'failingException' as a inner exception when throw from the catch clauses",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 14, column: 19)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, expected);
+        }
     }
 }

--- a/src/FunFair.CodeAnalysis/Helpers/ItemHelpers.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/ItemHelpers.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+
+namespace FunFair.CodeAnalysis.Helpers
+{
+    /// <summary>
+    ///     Item helpers
+    /// </summary>
+    public static class ItemHelpers
+    {
+        /// <summary>
+        ///     Removes nulls from the source collection.
+        /// </summary>
+        /// <param name="source">The source collection</param>
+        /// <typeparam name="TItemType">The item type</typeparam>
+        /// <returns>Collection without nulls.</returns>
+        public static IEnumerable<TItemType> RemoveNulls<TItemType>(this IEnumerable<TItemType?> source)
+            where TItemType : class
+        {
+            foreach (TItemType? item in source)
+            {
+                if (!ReferenceEquals(objA: item, objB: null))
+                {
+                    yield return item;
+                }
+            }
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/ReThrowingExceptionShouldSpecifyInnerExceptionDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ReThrowingExceptionShouldSpecifyInnerExceptionDiagnosticsAnalyzer.cs
@@ -40,11 +40,13 @@ namespace FunFair.CodeAnalysis
         {
             if (!(syntaxNodeAnalysisContext.Node is ClassDeclarationSyntax classDeclarationSyntax))
             {
+                return;
             }
 
             // if (!classDeclarationSyntax.Modifiers.Any(IsWhiteListedClassModifier))
             // {
-            //     syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(descriptor: Rule, classDeclarationSyntax.GetLocation()));
+            syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(descriptor: Rule, classDeclarationSyntax.GetLocation()));
+
             // }
         }
     }

--- a/src/FunFair.CodeAnalysis/ReThrowingExceptionShouldSpecifyInnerExceptionDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ReThrowingExceptionShouldSpecifyInnerExceptionDiagnosticsAnalyzer.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FunFair.CodeAnalysis
+{
+    /// <summary>
+    ///     Looks for catches which throw a new exception without passing the exception as an inner exception.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class ReThrowingExceptionShouldSpecifyInnerExceptionDiagnosticsAnalyzer : DiagnosticAnalyzer
+    {
+        private const string CATEGORY = "Classes";
+
+        private static readonly DiagnosticDescriptor Rule = RuleHelpers.CreateRule(code: Rules.RuleClassesShouldBeStaticSealedOrAbstract,
+                                                                                   category: CATEGORY,
+                                                                                   title: "Classes should be static, sealed or abstract",
+                                                                                   message: "Classes should be static, sealed or abstract");
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => new[] {Rule}.ToImmutableArray();
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterCompilationStartAction(PerformCheck);
+        }
+
+        private static void PerformCheck(CompilationStartAnalysisContext compilationStartContext)
+        {
+            compilationStartContext.RegisterSyntaxNodeAction(action: MustBeReadOnly, SyntaxKind.ClassDeclaration);
+        }
+
+        private static void MustBeReadOnly(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
+        {
+            if (!(syntaxNodeAnalysisContext.Node is ClassDeclarationSyntax classDeclarationSyntax))
+            {
+            }
+
+            // if (!classDeclarationSyntax.Modifiers.Any(IsWhiteListedClassModifier))
+            // {
+            //     syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(descriptor: Rule, classDeclarationSyntax.GetLocation()));
+            // }
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/Rules.cs
+++ b/src/FunFair.CodeAnalysis/Rules.cs
@@ -18,5 +18,6 @@ namespace FunFair.CodeAnalysis
         public const string RuleDontUseJsonSerializerWithoutJsonOptions = @"FFS0014";
         public const string RuleDontUseJsonDeserializerWithoutJsonOptions = @"FFS0015";
         public const string RuleMustPassParameterNameToArgumentExceptions = @"FFS0016";
+        public const string RuleMustPassInterExceptionToExceptionsThrownInCatchBlock = @"FFS0017";
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue\Feature

<!--- Please link to the issue or feature: -->
FF-2591

## How Has This Been Tested

- [x] All unit tests pass.
- [x] All integration tests pass.
- [x] Manual Testing: 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [x] Additional Unit Tests\Integration Tests
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

<!--- Insert Deployment configuration changes here -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes once they are true. -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [x] There are no Resharper\static code analysis errors anywhere in the solution.
- [x] I have run a code clean-up on any files I have modified to make sure they are in the correct format.
- [x] I have added tests to cover my changes.
- [x] I have run the code and quickly verified it all works to my satisfaction.
- [x] All new/modified code has sufficient logging to be able to diagnose what is wrong.
- [x] All new and existing tests passed.
- [x] All new/modified public interfaces/classes have are documented with xmldoc comments.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.
