### PR TITLE
[FF-2351] - Feature/ff 2351 prohibit use nsubstitute received without count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ Please ADD ALL Changes to the UNRELASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Added
+- FF-2351 - Prohibit use of NSubstitute.Received() without a count of items
 ### Fixed
+- FF-2413 - Amount of required arguments for DeserializeAsync
 ### Changed
 ### Removed
 ### Deployment Changes

--- a/src/FunFair.CodeAnalysis/ForceMethodParametersInvocationsDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ForceMethodParametersInvocationsDiagnosticsAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using FunFair.CodeAnalysis.Helpers;
@@ -47,7 +47,14 @@ namespace FunFair.CodeAnalysis
                                   sourceClass: "System.Text.Json.JsonSerializer",
                                   forcedMethod: "DeserializeAsync",
                                   new[] {new[] {"Stream", "JsonOptionsSerializer", "CancellationToken"}},
-                                  requiredArgumentCount: 3)
+                                  requiredArgumentCount: 2),
+            new ForcedMethodsSpec(ruleId: Rules.RuleDontUseSubstituteReceivedWithoutAmountOfCalls,
+                                  title: @"Avoid use of received without call count",
+                                  message: "Only use Received with expected call count",
+                                  sourceClass: "NSubstitute.SubstituteExtensions",
+                                  forcedMethod: "Received",
+                                  new[] {new[] {"int"}},
+                                  requiredArgumentCount: 1)
         };
 
         /// <inheritdoc />
@@ -122,13 +129,7 @@ namespace FunFair.CodeAnalysis
 
         private sealed class ForcedMethodsSpec
         {
-            public ForcedMethodsSpec(string ruleId,
-                                     string title,
-                                     string message,
-                                     string sourceClass,
-                                     string forcedMethod,
-                                     IEnumerable<IEnumerable<string>> forcedSignatures,
-                                     int requiredArgumentCount)
+            public ForcedMethodsSpec(string ruleId, string title, string message, string sourceClass, string forcedMethod, IEnumerable<IEnumerable<string>> forcedSignatures, int requiredArgumentCount)
             {
                 this.SourceClass = sourceClass;
                 this.ForcedMethod = forcedMethod;

--- a/src/FunFair.CodeAnalysis/Rules.cs
+++ b/src/FunFair.CodeAnalysis/Rules.cs
@@ -19,5 +19,6 @@ namespace FunFair.CodeAnalysis
         public const string RuleDontUseJsonDeserializerWithoutJsonOptions = @"FFS0015";
         public const string RuleMustPassParameterNameToArgumentExceptions = @"FFS0016";
         public const string RuleMustPassInterExceptionToExceptionsThrownInCatchBlock = @"FFS0017";
+        public const string RuleDontUseSubstituteReceivedWithoutAmountOfCalls = @"FFS0018";
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Prohibit use of NSubstitute.Received() without a count of items

## Related Issue\Feature

https://funfairtech.atlassian.net/browse/FF-2351

## How Has This Been Tested

- [x] All unit tests pass.
- [ ] All integration tests pass.
- [ ] Manual Testing: 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

<!--- Insert Deployment configuration changes here -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes once they are true. -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] There are no Resharper\static code analysis errors anywhere in the solution.
- [ ] I have run a code clean-up on any files I have modified to make sure they are in the correct format.
- [ ] I have added tests to cover my changes.
- [ ] I have run the code and quickly verified it all works to my satisfaction.
- [ ] All new/modified code has sufficient logging to be able to diagnose what is wrong.
- [x] All new and existing tests passed.
- [ ] All new/modified public interfaces/classes have are documented with xmldoc comments.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.
