### PR TITLE
[FF-2617] Stanadardise name of ILogger parameter names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please ADD ALL Changes to the UNRELASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Added
+- FF-2617 - ILogger parameters should be called 'logger'
 ### Fixed
 ### Changed
 ### Removed

--- a/src/FunFair.CodeAnalysis.Tests/FunFair.CodeAnalysis.Tests.csproj
+++ b/src/FunFair.CodeAnalysis.Tests/FunFair.CodeAnalysis.Tests.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="FunFair.Test.Common" Version="1.8.0.360" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.5"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.21" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/FunFair.CodeAnalysis.Tests/ParameterNameDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ParameterNameDiagnosticsAnalyzerTests.cs
@@ -1,0 +1,106 @@
+﻿using System.Threading.Tasks;
+using FunFair.CodeAnalysis.Tests.Helpers;
+using FunFair.CodeAnalysis.Tests.Verifiers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace FunFair.CodeAnalysis.Tests
+{
+    public sealed class ParameterNameDiagnosticsAnalyzerTests : CodeFixVerifier
+    {
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new ParameterNameDiagnosticsAnalyzer();
+        }
+
+        [Fact]
+        public Task GenericLoggerParameterNameInvalidAsync()
+        {
+            const string test = @"
+            using Microsoft.Extensions.Logging;
+
+            public sealed class Test {
+
+            public void DoIt(ILogger<Test> logging)
+            {
+            }
+}";
+
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0019",
+                                            Message = "ILogger parameters should be called 'logger'",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 6, column: 30)}
+                                        };
+
+            MetadataReference loggerReference = MetadataReference.CreateFromFile(typeof(ILogger<>).Assembly.Location);
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {loggerReference}, expected);
+        }
+
+        [Fact]
+        public Task GenericLoggerParameterNameIsValidAsync()
+        {
+            const string test = @"
+            using Microsoft.Extensions.Logging;
+
+            public sealed class Test {
+
+            public void DoIt(ILogger<Test> logger)
+            {
+            }
+}";
+
+            MetadataReference loggerReference = MetadataReference.CreateFromFile(typeof(ILogger<>).Assembly.Location);
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {loggerReference});
+        }
+
+        [Fact]
+        public Task LoggerParameterNameInvalidAsync()
+        {
+            const string test = @"
+            using Microsoft.Extensions.Logging;
+
+            public sealed class Test {
+
+            public void DoIt(ILogger logging)
+            {
+            }
+}";
+
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0019",
+                                            Message = "ILogger parameters should be called 'logger'",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 6, column: 30)}
+                                        };
+
+            MetadataReference loggerReference = MetadataReference.CreateFromFile(typeof(ILogger).Assembly.Location);
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {loggerReference}, expected);
+        }
+
+        [Fact]
+        public Task LoggerParameterNameIsValidAsync()
+        {
+            const string test = @"
+            using Microsoft.Extensions.Logging;
+
+            public sealed class Test {
+
+            public void DoIt(ILogger logger)
+            {
+            }
+}";
+
+            MetadataReference loggerReference = MetadataReference.CreateFromFile(typeof(ILogger).Assembly.Location);
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {loggerReference});
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/ArgumentExceptionAnalysisDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ArgumentExceptionAnalysisDiagnosticsAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Immutable;
 using System.Linq;
+using FunFair.CodeAnalysis.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/FunFair.CodeAnalysis/ClassAnalysisDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ClassAnalysisDiagnosticsAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Immutable;
 using System.Linq;
+using FunFair.CodeAnalysis.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/FunFair.CodeAnalysis/Helpers/LiteralString.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/LiteralString.cs
@@ -1,7 +1,7 @@
 using System;
 using Microsoft.CodeAnalysis;
 
-namespace FunFair.CodeAnalysis
+namespace FunFair.CodeAnalysis.Helpers
 {
     internal sealed class LiteralString : LocalizableString
     {

--- a/src/FunFair.CodeAnalysis/Helpers/Mapping.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/Mapping.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace FunFair.CodeAnalysis
+namespace FunFair.CodeAnalysis.Helpers
 {
     /// <summary>
     ///     Mapping class

--- a/src/FunFair.CodeAnalysis/Helpers/RuleHelpers.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/RuleHelpers.cs
@@ -1,6 +1,6 @@
 using Microsoft.CodeAnalysis;
 
-namespace FunFair.CodeAnalysis
+namespace FunFair.CodeAnalysis.Helpers
 {
     internal static class RuleHelpers
     {

--- a/src/FunFair.CodeAnalysis/Helpers/Rules.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/Rules.cs
@@ -1,4 +1,4 @@
-namespace FunFair.CodeAnalysis
+namespace FunFair.CodeAnalysis.Helpers
 {
     internal static class Rules
     {

--- a/src/FunFair.CodeAnalysis/Helpers/Rules.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/Rules.cs
@@ -20,5 +20,6 @@ namespace FunFair.CodeAnalysis.Helpers
         public const string RuleMustPassParameterNameToArgumentExceptions = @"FFS0016";
         public const string RuleMustPassInterExceptionToExceptionsThrownInCatchBlock = @"FFS0017";
         public const string RuleDontUseSubstituteReceivedWithoutAmountOfCalls = @"FFS0018";
+        public const string RuleLoggerParametersShouldBeCalledLogger = @"FFS0019";
     }
 }

--- a/src/FunFair.CodeAnalysis/ParameterNameDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ParameterNameDiagnosticsAnalyzer.cs
@@ -1,0 +1,126 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using FunFair.CodeAnalysis.Helpers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FunFair.CodeAnalysis
+{
+    /// <summary>
+    ///     Looks for issues with class declarations
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class ParameterNameDiagnosticsAnalyzer : DiagnosticAnalyzer
+    {
+        private const string CATEGORY = "Naming";
+
+        private static readonly NameSanitationSpec[] NameSpecifications =
+        {
+            new NameSanitationSpec(ruleId: Rules.RuleLoggerParametersShouldBeCalledLogger,
+                                   title: @"ILogger parameters should be called 'logger'",
+                                   message: "ILogger parameters should be called 'logger'",
+                                   sourceClass: "Microsoft.Extensions.Logging.ILogger",
+                                   whitelistedParameterName: "logger"),
+            new NameSanitationSpec(ruleId: Rules.RuleLoggerParametersShouldBeCalledLogger,
+                                   title: @"ILogger parameters should be called 'logger'",
+                                   message: "ILogger parameters should be called 'logger'",
+                                   sourceClass: "Microsoft.Extensions.Logging.ILogger<TCategoryName>",
+                                   whitelistedParameterName: "logger")
+        };
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            NameSpecifications.Select(selector: r => r.Rule)
+                              .ToImmutableArray();
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterCompilationStartAction(this.PerformCheck);
+        }
+
+        private void PerformCheck(CompilationStartAnalysisContext compilationStartContext)
+        {
+            compilationStartContext.RegisterSyntaxNodeAction(action: this.MustHaveASaneName, SyntaxKind.Parameter);
+        }
+
+        private void MustHaveASaneName(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
+        {
+            if (syntaxNodeAnalysisContext.Node is ParameterSyntax ps)
+            {
+                IParameterSymbol? ds = syntaxNodeAnalysisContext.SemanticModel.GetDeclaredSymbol(ps);
+
+                if (ds != null)
+                {
+                    ITypeSymbol dsType = GetTypeSymbol(ds);
+
+                    string fullType = dsType.ToDisplayString();
+
+                    NameSanitationSpec? rule = NameSpecifications.FirstOrDefault(ns => ns.SourceClass == fullType);
+
+                    if (rule != null)
+                    {
+                        if (!rule.WhitelistedParameterNames.Contains(ps.Identifier.Text))
+                        {
+                            syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(descriptor: rule.Rule, ps.GetLocation()));
+                        }
+                    }
+                }
+            }
+        }
+
+        private static ITypeSymbol GetTypeSymbol(IParameterSymbol ds)
+        {
+            ITypeSymbol dsType = ds.Type;
+
+            if (dsType is INamedTypeSymbol nts && nts.IsGenericType)
+            {
+                dsType = dsType.OriginalDefinition;
+            }
+
+            return dsType;
+        }
+
+        private sealed class NameSanitationSpec
+        {
+            public NameSanitationSpec(string ruleId, string title, string message, string sourceClass, string whitelistedParameterName)
+                : this(ruleId: ruleId, title: title, message: message, sourceClass: sourceClass, new[] {whitelistedParameterName})
+            {
+            }
+
+            public NameSanitationSpec(string ruleId, string title, string message, string sourceClass, string[] whitelistedParameterNames)
+            {
+                this.SourceClass = sourceClass;
+                this.WhitelistedParameterNames = whitelistedParameterNames;
+
+                this.Rule = CreateRule(code: ruleId, title: title, message: message);
+            }
+
+            public string SourceClass { get; }
+
+            public IReadOnlyList<string> WhitelistedParameterNames { get; }
+
+            public DiagnosticDescriptor Rule { get; }
+
+            private static DiagnosticDescriptor CreateRule(string code, string title, string message)
+            {
+                LiteralString translatableTitle = new LiteralString(title);
+                LiteralString translatableMessage = new LiteralString(message);
+
+                return new DiagnosticDescriptor(id: code,
+                                                title: translatableTitle,
+                                                messageFormat: translatableMessage,
+                                                category: CATEGORY,
+                                                defaultSeverity: DiagnosticSeverity.Error,
+                                                isEnabledByDefault: true,
+                                                description: translatableMessage);
+            }
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/ProhibitedMethodsDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ProhibitedMethodsDiagnosticsAnalyzer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using FunFair.CodeAnalysis.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/FunFair.CodeAnalysis/ProhibitedPragmaDiagnosticsAnalyzercs.cs
+++ b/src/FunFair.CodeAnalysis/ProhibitedPragmaDiagnosticsAnalyzercs.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using FunFair.CodeAnalysis.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/FunFair.CodeAnalysis/StructAnalysisDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/StructAnalysisDiagnosticsAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Immutable;
 using System.Linq;
+using FunFair.CodeAnalysis.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/FunFair.CodeAnalysis/TestClassAnalysisDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/TestClassAnalysisDiagnosticsAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Immutable;
 using System.Linq;
+using FunFair.CodeAnalysis.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue\Feature

<!--- Please link to the issue or feature: -->
FF-2617

## How Has This Been Tested

- [x] All unit tests pass.
- [x] All integration tests pass.
- [ ] Manual Testing: 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

<!--- Insert Deployment configuration changes here -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes once they are true. -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [x] There are no Resharper\static code analysis errors anywhere in the solution.
- [x] I have run a code clean-up on any files I have modified to make sure they are in the correct format.
- [x] I have added tests to cover my changes.
- [x] I have run the code and quickly verified it all works to my satisfaction.
- [x] All new/modified code has sufficient logging to be able to diagnose what is wrong.
- [x] All new and existing tests passed.
- [x] All new/modified public interfaces/classes have are documented with xmldoc comments.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.
