### PR TITLE
[FF-2616] - Feature/ff 2616 catch compiler errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please ADD ALL Changes to the UNRELASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Added
+- FF-2616 - Check compiler errors in unit test source code
 ### Fixed
 ### Changed
 ### Removed

--- a/src/FunFair.CodeAnalysis.Tests/ArgumentExceptionAnalysisDiagnosticsAnalyzerTest.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ArgumentExceptionAnalysisDiagnosticsAnalyzerTest.cs
@@ -160,7 +160,7 @@ public sealed class Test {
 
     public void DoIt(string value)
     {
-        var x = new ArgumentNUllException(""Hello World"", nameof(value));
+        var x = new ArgumentNullException(""Hello World"", nameof(value));
         
     }
 }";
@@ -280,7 +280,7 @@ public sealed class Test {
 
     public void DoIt(string value)
     {
-        var x = new String(nameof(value));
+        var x = new string(nameof(value));
     }
 }";
 

--- a/src/FunFair.CodeAnalysis.Tests/Exceptions/UnitTestSourceException.cs
+++ b/src/FunFair.CodeAnalysis.Tests/Exceptions/UnitTestSourceException.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace FunFair.CodeAnalysis.Tests.Exceptions
+{
+    /// <summary>
+    ///     Raised when the verified code is invalid.
+    /// </summary>
+    public sealed class UnitTestSourceException : Exception
+    {
+        /// <summary>
+        ///     Constructor.
+        /// </summary>
+
+        // ReSharper disable once UnusedMember.Global
+        public UnitTestSourceException()
+            : this(message: "House not ready")
+        {
+        }
+
+        /// <summary>
+        ///     Constructor.
+        /// </summary>
+        /// <param name="message">The message to return.</param>
+        public UnitTestSourceException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        ///     Constructor.
+        /// </summary>
+        /// <param name="message">The message to return.</param>
+        /// <param name="innerException">The inner exception.</param>
+
+        // ReSharper disable once UnusedMember.Global
+        public UnitTestSourceException(string message, Exception innerException)
+            : base(message: message, innerException: innerException)
+        {
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis.Tests/ForcedMethodParametersInvocationsDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ForcedMethodParametersInvocationsDiagnosticsAnalyzerTests.cs
@@ -41,7 +41,7 @@ namespace FunFair.CodeAnalysis.Tests
 
             MetadataReference reference = MetadataReference.CreateFromFile(typeof(JsonSerializer).Assembly.Location);
 
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {reference});
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {reference });
         }
 
         [Fact]

--- a/src/FunFair.CodeAnalysis.Tests/FunFair.CodeAnalysis.Tests.csproj
+++ b/src/FunFair.CodeAnalysis.Tests/FunFair.CodeAnalysis.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="FunFair.Test.Common" Version="1.8.0.360" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.5"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.21" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodInvocationsDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodInvocationsDiagnosticsAnalyzerTests.cs
@@ -18,7 +18,6 @@ namespace FunFair.CodeAnalysis.Tests
         public Task AssertFalseWithMessageIsAllowedAsync()
         {
             const string test = @"
-     using System;
      using Xunit;
 
      namespace ConsoleApplication1
@@ -31,15 +30,16 @@ namespace FunFair.CodeAnalysis.Tests
              }
          }
      }";
+            
+            MetadataReference reference = MetadataReference.CreateFromFile(typeof(Assert).Assembly.Location);
 
-            return this.VerifyCSharpDiagnosticAsync(test);
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {reference});
         }
 
         [Fact]
         public Task AssertFalseWithoutMessageIsBannedAsync()
         {
             const string test = @"
-    using System;
     using Xunit;
 
     namespace ConsoleApplication1
@@ -49,7 +49,7 @@ namespace FunFair.CodeAnalysis.Tests
         {
             void Test()
             {
-                Xunit.Assert.False(false);
+                Assert.False(false);
             }
         }
     }";
@@ -58,7 +58,7 @@ namespace FunFair.CodeAnalysis.Tests
                                             Id = "FFS0010",
                                             Message = @"Only use Assert.False with message parameter",
                                             Severity = DiagnosticSeverity.Error,
-                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 17)}
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 11, column: 17)}
                                         };
 
             MetadataReference reference = MetadataReference.CreateFromFile(typeof(Assert).Assembly.Location);
@@ -70,7 +70,6 @@ namespace FunFair.CodeAnalysis.Tests
         public Task AssertTrueWithMessageIsAllowedAsync()
         {
             const string test = @"
-    using System;
     using Xunit;
 
     namespace ConsoleApplication1
@@ -94,7 +93,6 @@ namespace FunFair.CodeAnalysis.Tests
         public Task AssertTrueWithoutMessageIsBannedAsync()
         {
             const string test = @"
-     using System;
      using Xunit;
 
      namespace ConsoleApplication1
@@ -112,7 +110,7 @@ namespace FunFair.CodeAnalysis.Tests
                                             Id = "FFS0009",
                                             Message = @"Only use Assert.True with message parameter",
                                             Severity = DiagnosticSeverity.Error,
-                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 11, column: 18)}
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 10, column: 18)}
                                         };
 
             MetadataReference reference = MetadataReference.CreateFromFile(typeof(Assert).Assembly.Location);

--- a/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodsDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodsDiagnosticsAnalyzerTests.cs
@@ -104,6 +104,7 @@ namespace FunFair.CodeAnalysis.Tests
         {
             const string test = @"
     using System;
+    using System.Diagnostics;
 
     namespace ConsoleApplication1
     {
@@ -113,7 +114,23 @@ namespace FunFair.CodeAnalysis.Tests
 
             public static bool operator ==(TypeName left, TypeName right)
             {
-                return left == right || left == DateTime.Now;
+                Debug.Write(DateTime.Now);
+                return left == right;
+            }
+
+            public static bool operator !=(TypeName left, TypeName right)
+            {
+                return left == right;
+            }
+
+            public override int GetHashCode()
+            {
+                return 1;
+            }
+            
+            public override bool Equals(object obj)
+            {
+                return false;
             }
         }
     }";
@@ -122,7 +139,7 @@ namespace FunFair.CodeAnalysis.Tests
                                             Id = "FFS0001",
                                             Message = @"Call IDateTimeSource.UtcNow() rather than DateTime.Now",
                                             Severity = DiagnosticSeverity.Error,
-                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 49)}
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 13, column: 29)}
                                         };
 
             return this.VerifyCSharpDiagnosticAsync(source: test, expected);
@@ -270,8 +287,7 @@ namespace FunFair.CodeAnalysis.Tests
         public Task ExecuteArbitrarySqlAsyncIsBannedAsync()
         {
             const string test = @"
-    using System;
-
+    using System.Threading.Tasks;
     namespace FunFair.Common.Data
     {
          public interface ISqlServerDatabase
@@ -296,9 +312,9 @@ namespace FunFair.CodeAnalysis.Tests
                                             Id = "FFS0006",
                                             Message = @"Only use ISqlServerDatabase.ExecuteArbitrarySqlAsync in integration tests",
                                             Severity = DiagnosticSeverity.Error,
-                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 19, column: 17)}
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 18, column: 17)}
                                         };
-
+            
             return this.VerifyCSharpDiagnosticAsync(source: test, expected);
         }
 
@@ -314,7 +330,8 @@ namespace FunFair.CodeAnalysis.Tests
         public Task QueryArbitrarySqlAsyncGenericIsBannedAsync()
         {
             const string test = @"
-    using System;
+
+    using System.Threading.Tasks;
 
     namespace FunFair.Common.Data
     {
@@ -335,7 +352,7 @@ namespace FunFair.CodeAnalysis.Tests
         {
             void Test(FunFair.Common.Data.ISqlServerDatabase sqlServerDatabase, string sql)
             {
-                sqlServerDatabase.QueryArbitrarySqlAsync<Test>(sql)
+                sqlServerDatabase.QueryArbitrarySqlAsync<Test>(sql);
             }
         }
     }";
@@ -344,7 +361,7 @@ namespace FunFair.CodeAnalysis.Tests
                                             Id = "FFS0007",
                                             Message = @"Only use ISqlServerDatabase.QueryArbitrarySqlAsync in integration tests",
                                             Severity = DiagnosticSeverity.Error,
-                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 23, column: 17)}
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 24, column: 17)}
                                         };
 
             return this.VerifyCSharpDiagnosticAsync(source: test, expected);
@@ -354,7 +371,7 @@ namespace FunFair.CodeAnalysis.Tests
         public Task QueryArbitrarySqlAsyncIsBannedAsync()
         {
             const string test = @"
-    using System;
+    using System.Threading.Tasks;
 
     namespace FunFair.Common.Data
     {
@@ -370,7 +387,7 @@ namespace FunFair.CodeAnalysis.Tests
         {
             void Test(FunFair.Common.Data.ISqlServerDatabase sqlServerDatabase, string sql)
             {
-                sqlServerDatabase.QueryArbitrarySqlAsync(sql)
+                sqlServerDatabase.QueryArbitrarySqlAsync(sql);
             }
         }
     }";

--- a/src/FunFair.CodeAnalysis.Tests/ProhibitedPragmasDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ProhibitedPragmasDiagnosticsAnalyzerTests.cs
@@ -40,19 +40,25 @@ namespace FunFair.CodeAnalysis.Tests
         [Fact]
         public Task BannedWarningCannotBeDisabledInMethodAsync()
         {
-            const string test = @"void DoIt()
-{
-#pragma warning disable CS1234
-    int i = 2;
-}
-";
+            const string test = @"
+
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {
+            void DoIt()
+            {
+            #pragma warning disable CS1234
+            }
+        }
+    }";
 
             DiagnosticResult expected = new DiagnosticResult
                                         {
                                             Id = "FFS0008",
                                             Message = "Don't disable warnings using #pragma warning disable",
                                             Severity = DiagnosticSeverity.Error,
-                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 3, column: 25)}
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 9, column: 37)}
                                         };
 
             return this.VerifyCSharpDiagnosticAsync(source: test, expected);

--- a/src/FunFair.CodeAnalysis.Tests/ReThrowingExceptionShouldSpecifyInnerExceptionDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ReThrowingExceptionShouldSpecifyInnerExceptionDiagnosticsAnalyzerTests.cs
@@ -18,23 +18,25 @@ namespace FunFair.CodeAnalysis.Tests
         public Task ReThrowingExceptionShouldNotTriggerErrorAsync()
         {
             const string test = @"
-using System;
+    using System;
 
-public sealed class Test {
-
-    public void DoIt()
+    namespace ConsoleApplication1
     {
-        try
+        public class Test 
         {
-        }
-        catch(Exception exception)
-        {
-            Console.WriteLine(exception.Message);
-            throw;
-        }
-    }
-}";
-
+            public void DoIt()
+            {
+                    try
+                    {
+                    }
+                    catch(Exception failingException)
+                    {
+                        Console.WriteLine(failingException.Message);
+                        throw;
+                    }
+            }
+         }
+    }";
             return this.VerifyCSharpDiagnosticAsync(source: test);
         }
 
@@ -51,10 +53,10 @@ public sealed class Test {
         try
         {
         }
-        catch(Exception exception)
+        catch(Exception failingException)
         {
-            Console.WriteLine(exception.Message);
-            throw new NotImplementedException(""Not Implemented yet"", exception);
+            Console.WriteLine(failingException.Message);
+            throw new NotImplementedException(""Not Implemented yet"", failingException);
         }
     }
 }";
@@ -77,7 +79,7 @@ public sealed class Test {
         }
         catch(Exception failingException)
         {
-            Console.WriteLine(exception.Message);
+            Console.WriteLine(failingException.Message);
             throw new NotImplementedException(""Not Implemented yet"", new Exception(""Oops""));
         }
     }
@@ -109,7 +111,7 @@ public sealed class Test {
         }
         catch(Exception failingException)
         {
-            Console.WriteLine(exception.Message);
+            Console.WriteLine(failingException.Message);
             throw new NotImplementedException();
         }
     }

--- a/src/FunFair.CodeAnalysis.Tests/TestClassAnalysisDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/TestClassAnalysisDiagnosticsAnalyzerTests.cs
@@ -5,6 +5,7 @@ using FunFair.Test.Common;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace FunFair.CodeAnalysis.Tests
 {
@@ -64,19 +65,26 @@ using Xunit;
             const string test = @"
 using FunFair.Test.Common;
 using Xunit;
+using Xunit.Abstractions;
 
             public sealed class Test : LoggingTestBase {
+
+            public Test(ITestOutputHelper output)
+                : base(output)
+            {
+            }
 
             [Fact]
             public void DoIt()
             {
             }
 }";
-
+            
+            MetadataReference xunitAbstractionsReference = MetadataReference.CreateFromFile(typeof(ITestOutputHelper).Assembly.Location);
             MetadataReference xunitReference = MetadataReference.CreateFromFile(typeof(FactAttribute).Assembly.Location);
-            MetadataReference ffTestReference = MetadataReference.CreateFromFile(typeof(TestBase).Assembly.Location);
+            MetadataReference ffTestReference = MetadataReference.CreateFromFile(typeof(LoggingTestBase).Assembly.Location);
 
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {xunitReference, ffTestReference});
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {xunitReference, ffTestReference, xunitAbstractionsReference});
         }
 
         [Fact]
@@ -132,8 +140,14 @@ using Xunit;
             const string test = @"
 using FunFair.Test.Common;
 using Xunit;
+using Xunit.Abstractions;
 
             public sealed class Test : LoggingTestBase {
+
+            public Test(ITestOutputHelper output)
+                : base(output)
+            {
+            }
 
             [Theory]
             [InlineData(1)]
@@ -142,10 +156,11 @@ using Xunit;
             }
 }";
 
+            MetadataReference xunitAbstractionsReference = MetadataReference.CreateFromFile(typeof(ITestOutputHelper).Assembly.Location);
             MetadataReference xunitReference = MetadataReference.CreateFromFile(typeof(FactAttribute).Assembly.Location);
-            MetadataReference ffTestReference = MetadataReference.CreateFromFile(typeof(TestBase).Assembly.Location);
+            MetadataReference ffTestReference = MetadataReference.CreateFromFile(typeof(LoggingTestBase).Assembly.Location);
 
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {xunitReference, ffTestReference});
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {xunitReference, ffTestReference, xunitAbstractionsReference});
         }
 
         [Fact]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Check compiler error in unit test source code in code analysis solution and throw exception

## Related Issue\Feature

https://funfairtech.atlassian.net/browse/FF-2616

## How Has This Been Tested

- [x] All unit tests pass.
- [ ] All integration tests pass.
- [ ] Manual Testing: 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

<!--- Insert Deployment configuration changes here -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes once they are true. -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [x] There are no Resharper\static code analysis errors anywhere in the solution.
- [x] I have run a code clean-up on any files I have modified to make sure they are in the correct format.
- [x] I have added tests to cover my changes.
- [ ] I have run the code and quickly verified it all works to my satisfaction.
- [ ] All new/modified code has sufficient logging to be able to diagnose what is wrong.
- [x] All new and existing tests passed.
- [x] All new/modified public interfaces/classes have are documented with xmldoc comments.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.
