### PR TITLE
[FF-2623] - parameter ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please ADD ALL Changes to the UNRELASED SECTION and not a specific release
 ## [Unreleased]
 ### Added
 - FF-2616 - Check compiler errors in unit test source code
+- FF-2623 - Check parameter ordering to make logger parameters last or next to last.
 ### Fixed
 ### Changed
 - FF-1429 - Updated FunFair.Test.Common to 1.8.1.387

--- a/src/FunFair.CodeAnalysis.Tests/ForcedMethodParametersInvocationsDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ForcedMethodParametersInvocationsDiagnosticsAnalyzerTests.cs
@@ -1,10 +1,8 @@
-﻿using System.Text.Json;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using FunFair.CodeAnalysis.Tests.Helpers;
 using FunFair.CodeAnalysis.Tests.Verifiers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using NSubstitute;
 using Xunit;
 
 namespace FunFair.CodeAnalysis.Tests
@@ -39,9 +37,7 @@ namespace FunFair.CodeAnalysis.Tests
         }
     }";
 
-            MetadataReference reference = MetadataReference.CreateFromFile(typeof(JsonSerializer).Assembly.Location);
-
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {reference });
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.JsonSerializer});
         }
 
         [Fact]
@@ -74,9 +70,64 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 15, column: 29)}
                                         };
 
-            MetadataReference reference = MetadataReference.CreateFromFile(typeof(JsonSerializer).Assembly.Location);
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.JsonSerializer}, expected);
+        }
 
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {reference}, expected);
+        [Fact]
+        public Task NSubstituteExtensionsReceivedWithExpectedCallCountIsPassingAsync()
+        {
+            const string test = @"
+     using NSubstitute;
+
+     namespace ConsoleApplication1
+     {
+         public interface IDoSomething
+          {
+                 void DoIt();
+          }
+
+         class TypeName
+         {
+             void Test()
+             {
+                 Substitute.For<IDoSomething>().Received(1).DoIt();
+             }
+         }
+     }";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Substitute});
+        }
+
+        [Fact]
+        public Task NSubstituteExtensionsReceivedWithoutExpectedCallCountIsBannedAsync()
+        {
+            const string test = @"
+     using NSubstitute;
+
+     namespace ConsoleApplication1
+     {
+         public interface IDoSomething
+          {
+                 void DoIt();
+          }
+
+         class TypeName
+         {
+             void Test()
+             {
+                 Substitute.For<IDoSomething>().Received().DoIt();
+             }
+         }
+     }";
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0018",
+                                            Message = @"Only use Received with expected call count",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 15, column: 18)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Substitute}, expected);
         }
 
         [Fact]
@@ -102,9 +153,7 @@ namespace FunFair.CodeAnalysis.Tests
         }
     }";
 
-            MetadataReference reference = MetadataReference.CreateFromFile(typeof(JsonSerializer).Assembly.Location);
-
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {reference});
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.JsonSerializer});
         }
 
         [Fact]
@@ -136,70 +185,7 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 15, column: 34)}
                                         };
 
-            MetadataReference reference = MetadataReference.CreateFromFile(typeof(JsonSerializer).Assembly.Location);
-
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {reference}, expected);
-        }
-        
-        [Fact]
-        public Task NSubstituteExtensionsReceivedWithoutExpectedCallCountIsBannedAsync()
-        {
-            const string test = @"
-     using NSubstitute;
-
-     namespace ConsoleApplication1
-     {
-         public interface IDoSomething
-          {
-                 void DoIt();
-          }
-
-         class TypeName
-         {
-             void Test()
-             {
-                 Substitute.For<IDoSomething>().Received().DoIt();
-             }
-         }
-     }";
-            DiagnosticResult expected = new DiagnosticResult
-                                        {
-                                            Id = "FFS0018",
-                                            Message = @"Only use Received with expected call count",
-                                            Severity = DiagnosticSeverity.Error,
-                                            Locations = new[] { new DiagnosticResultLocation(path: "Test0.cs", line: 15, column: 18) }
-                                        };
-
-            MetadataReference reference = MetadataReference.CreateFromFile(typeof(Substitute).Assembly.Location);
-
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {reference}, expected);
-        }
-        
-        [Fact]
-        public Task NSubstituteExtensionsReceivedWithExpectedCallCountIsPassingAsync()
-        {
-            const string test = @"
-     using NSubstitute;
-
-     namespace ConsoleApplication1
-     {
-         public interface IDoSomething
-          {
-                 void DoIt();
-          }
-
-         class TypeName
-         {
-             void Test()
-             {
-                 Substitute.For<IDoSomething>().Received(1).DoIt();
-             }
-         }
-     }";
-            
-            MetadataReference reference = MetadataReference.CreateFromFile(typeof(Substitute).Assembly.Location);
-
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {reference});
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.JsonSerializer}, expected);
         }
     }
 }

--- a/src/FunFair.CodeAnalysis.Tests/Helpers/WellKnownMetadataReferences.cs
+++ b/src/FunFair.CodeAnalysis.Tests/Helpers/WellKnownMetadataReferences.cs
@@ -1,0 +1,32 @@
+﻿using System.Text.Json;
+using System.Threading;
+using FunFair.Test.Common;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FunFair.CodeAnalysis.Tests.Helpers
+{
+    internal static class WellKnownMetadataReferences
+    {
+        public static readonly MetadataReference GenericLogger = MetadataReference.CreateFromFile(typeof(ILogger<>).Assembly.Location);
+
+        public static readonly MetadataReference Logger = MetadataReference.CreateFromFile(typeof(ILogger).Assembly.Location);
+
+        public static readonly MetadataReference CancellationToken = MetadataReference.CreateFromFile(typeof(CancellationToken).Assembly.Location);
+
+        public static readonly MetadataReference JsonSerializer = MetadataReference.CreateFromFile(typeof(JsonSerializer).Assembly.Location);
+
+        public static readonly MetadataReference Substitute = MetadataReference.CreateFromFile(typeof(Substitute).Assembly.Location);
+
+        public static readonly MetadataReference Assert = MetadataReference.CreateFromFile(typeof(Assert).Assembly.Location);
+
+        public static readonly MetadataReference Xunit = MetadataReference.CreateFromFile(typeof(FactAttribute).Assembly.Location);
+
+        public static readonly MetadataReference XunitAbstractions = MetadataReference.CreateFromFile(typeof(ITestOutputHelper).Assembly.Location);
+
+        public static readonly MetadataReference FunFairTestCommon = MetadataReference.CreateFromFile(typeof(TestBase).Assembly.Location);
+    }
+}

--- a/src/FunFair.CodeAnalysis.Tests/ParameterNameDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ParameterNameDiagnosticsAnalyzerTests.cs
@@ -3,7 +3,6 @@ using FunFair.CodeAnalysis.Tests.Helpers;
 using FunFair.CodeAnalysis.Tests.Verifiers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace FunFair.CodeAnalysis.Tests
@@ -36,9 +35,7 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 6, column: 30)}
                                         };
 
-            MetadataReference loggerReference = MetadataReference.CreateFromFile(typeof(ILogger<>).Assembly.Location);
-
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {loggerReference}, expected);
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.GenericLogger}, expected);
         }
 
         [Fact]
@@ -54,9 +51,7 @@ namespace FunFair.CodeAnalysis.Tests
             }
 }";
 
-            MetadataReference loggerReference = MetadataReference.CreateFromFile(typeof(ILogger<>).Assembly.Location);
-
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {loggerReference});
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.GenericLogger});
         }
 
         [Fact]
@@ -80,9 +75,7 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 6, column: 30)}
                                         };
 
-            MetadataReference loggerReference = MetadataReference.CreateFromFile(typeof(ILogger).Assembly.Location);
-
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {loggerReference}, expected);
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Logger}, expected);
         }
 
         [Fact]
@@ -98,9 +91,7 @@ namespace FunFair.CodeAnalysis.Tests
             }
 }";
 
-            MetadataReference loggerReference = MetadataReference.CreateFromFile(typeof(ILogger).Assembly.Location);
-
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {loggerReference});
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Logger});
         }
     }
 }

--- a/src/FunFair.CodeAnalysis.Tests/ParameterOrderingDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ParameterOrderingDiagnosticsAnalyzerTests.cs
@@ -15,7 +15,39 @@ namespace FunFair.CodeAnalysis.Tests
         }
 
         [Fact]
-        public Task LoggerParameterShouldBeLastWhenNoCancellationTokenAsync()
+        public Task GenericLoggerAsLastParameterIsNotAnErrorAsync()
+        {
+            const string test = @"
+            using Microsoft.Extensions.Logging;
+
+            public sealed class Test {
+
+            public void DoIt(string banana, ILogger<Test> logger)
+            {
+            }
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.GenericLogger});
+        }
+
+        [Fact]
+        public Task GenericLoggerAsOnlyParameterIsNotAnErrorAsync()
+        {
+            const string test = @"
+            using Microsoft.Extensions.Logging;
+
+            public sealed class Test {
+
+            public void DoIt(ILogger<Test> logger)
+            {
+            }
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.GenericLogger});
+        }
+
+        [Fact]
+        public Task GenericLoggerParameterShouldBeLastWhenNoCancellationTokenAsync()
         {
             const string test = @"
             using Microsoft.Extensions.Logging;
@@ -23,6 +55,87 @@ namespace FunFair.CodeAnalysis.Tests
             public sealed class Test {
 
             public void DoIt(ILogger<Test> logger, string banana)
+            {
+            }
+}";
+
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0020",
+                                            Message = "Parameter 'logger' must be parameter 2",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 6, column: 30)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.GenericLogger}, expected);
+        }
+
+        [Fact]
+        public Task GenericLoggerParameterShouldBeNextLastWhenCancellationTokenAsync()
+        {
+            const string test = @"
+            using System.Threading;
+            using Microsoft.Extensions.Logging;
+
+            public sealed class Test {
+
+            public void DoIt(ILogger<Test> logger, string banana, CancellationToken cancellationToken)
+            {
+            }
+}";
+
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0020",
+                                            Message = "Parameter 'logger' must be parameter 2",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 7, column: 30)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.GenericLogger, WellKnownMetadataReferences.CancellationToken}, expected);
+        }
+
+        [Fact]
+        public Task LoggerAsLastParameterIsNotAnErrorAsync()
+        {
+            const string test = @"
+            using Microsoft.Extensions.Logging;
+
+            public sealed class Test {
+
+            public void DoIt(string banana, ILogger logger)
+            {
+            }
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.GenericLogger});
+        }
+
+        [Fact]
+        public Task LoggerAsOnlyParameterIsNotAnErrorAsync()
+        {
+            const string test = @"
+            using Microsoft.Extensions.Logging;
+
+            public sealed class Test {
+
+            public void DoIt(ILogger logger)
+            {
+            }
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.GenericLogger});
+        }
+
+        [Fact]
+        public Task LoggerParameterShouldBeLastWhenNoCancellationTokenAsync()
+        {
+            const string test = @"
+            using Microsoft.Extensions.Logging;
+
+            public sealed class Test {
+
+            public void DoIt(ILogger logger, string banana)
             {
             }
 }";
@@ -47,7 +160,7 @@ namespace FunFair.CodeAnalysis.Tests
 
             public sealed class Test {
 
-            public void DoIt(ILogger<Test> logger, string banana, CancellationToken cancellationToken)
+            public void DoIt(ILogger logger, string banana, CancellationToken cancellationToken)
             {
             }
 }";

--- a/src/FunFair.CodeAnalysis.Tests/ParameterOrderingDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ParameterOrderingDiagnosticsAnalyzerTests.cs
@@ -57,7 +57,7 @@ namespace FunFair.CodeAnalysis.Tests
                                             Id = "FFS0020",
                                             Message = "Parameter 'logger' must be parameter 2",
                                             Severity = DiagnosticSeverity.Error,
-                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 6, column: 30)}
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 7, column: 30)}
                                         };
 
             return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.GenericLogger, WellKnownMetadataReferences.CancellationToken}, expected);

--- a/src/FunFair.CodeAnalysis.Tests/ParameterOrderingDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ParameterOrderingDiagnosticsAnalyzerTests.cs
@@ -128,6 +128,22 @@ namespace FunFair.CodeAnalysis.Tests
         }
 
         [Fact]
+        public Task LoggerExtensionMethodIsValidAsFirstParameterAsync()
+        {
+            const string test = @"
+            using Microsoft.Extensions.Logging;
+
+            public static class Test {
+
+            public static void DoIt(this ILogger logger, string banana)
+            {
+            }
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.GenericLogger});
+        }
+
+        [Fact]
         public Task LoggerParameterShouldBeLastWhenNoCancellationTokenAsync()
         {
             const string test = @"

--- a/src/FunFair.CodeAnalysis.Tests/ParameterOrderingDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ParameterOrderingDiagnosticsAnalyzerTests.cs
@@ -1,0 +1,66 @@
+﻿using System.Threading.Tasks;
+using FunFair.CodeAnalysis.Tests.Helpers;
+using FunFair.CodeAnalysis.Tests.Verifiers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace FunFair.CodeAnalysis.Tests
+{
+    public sealed class ParameterOrderingDiagnosticsAnalyzerTests : CodeFixVerifier
+    {
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new ParameterOrderingDiagnosticsAnalyzer();
+        }
+
+        [Fact]
+        public Task LoggerParameterShouldBeLastWhenNoCancellationTokenAsync()
+        {
+            const string test = @"
+            using Microsoft.Extensions.Logging;
+
+            public sealed class Test {
+
+            public void DoIt(ILogger<Test> logger, string banana)
+            {
+            }
+}";
+
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0020",
+                                            Message = "Parameter 'logger' must be parameter 2",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 6, column: 30)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.GenericLogger}, expected);
+        }
+
+        [Fact]
+        public Task LoggerParameterShouldBeNextLastWhenCancellationTokenAsync()
+        {
+            const string test = @"
+            using System.Threading;
+            using Microsoft.Extensions.Logging;
+
+            public sealed class Test {
+
+            public void DoIt(ILogger<Test> logger, string banana, CancelationToken cancellationToken)
+            {
+            }
+}";
+
+            DiagnosticResult expected = new DiagnosticResult
+                                        {
+                                            Id = "FFS0020",
+                                            Message = "Parameter 'logger' must be parameter 2",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 6, column: 30)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.GenericLogger, WellKnownMetadataReferences.CancellationToken}, expected);
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis.Tests/ParameterOrderingDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ParameterOrderingDiagnosticsAnalyzerTests.cs
@@ -47,7 +47,7 @@ namespace FunFair.CodeAnalysis.Tests
 
             public sealed class Test {
 
-            public void DoIt(ILogger<Test> logger, string banana, CancelationToken cancellationToken)
+            public void DoIt(ILogger<Test> logger, string banana, CancellationToken cancellationToken)
             {
             }
 }";

--- a/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodInvocationsDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodInvocationsDiagnosticsAnalyzerTests.cs
@@ -30,10 +30,8 @@ namespace FunFair.CodeAnalysis.Tests
              }
          }
      }";
-            
-            MetadataReference reference = MetadataReference.CreateFromFile(typeof(Assert).Assembly.Location);
 
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {reference});
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Assert});
         }
 
         [Fact]
@@ -61,9 +59,7 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 11, column: 17)}
                                         };
 
-            MetadataReference reference = MetadataReference.CreateFromFile(typeof(Assert).Assembly.Location);
-
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {reference}, expected);
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Assert}, expected);
         }
 
         [Fact]
@@ -84,9 +80,7 @@ namespace FunFair.CodeAnalysis.Tests
         }
     }";
 
-            MetadataReference reference = MetadataReference.CreateFromFile(typeof(Assert).Assembly.Location);
-
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {reference});
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Assert});
         }
 
         [Fact]
@@ -113,9 +107,7 @@ namespace FunFair.CodeAnalysis.Tests
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 10, column: 18)}
                                         };
 
-            MetadataReference reference = MetadataReference.CreateFromFile(typeof(Assert).Assembly.Location);
-
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {reference}, expected);
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Assert}, expected);
         }
     }
 }

--- a/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodsDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodsDiagnosticsAnalyzerTests.cs
@@ -314,7 +314,7 @@ namespace FunFair.CodeAnalysis.Tests
                                             Severity = DiagnosticSeverity.Error,
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 18, column: 17)}
                                         };
-            
+
             return this.VerifyCSharpDiagnosticAsync(source: test, expected);
         }
 

--- a/src/FunFair.CodeAnalysis.Tests/ReThrowingExceptionShouldSpecifyInnerExceptionDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ReThrowingExceptionShouldSpecifyInnerExceptionDiagnosticsAnalyzerTests.cs
@@ -37,6 +37,7 @@ namespace FunFair.CodeAnalysis.Tests
             }
          }
     }";
+
             return this.VerifyCSharpDiagnosticAsync(source: test);
         }
 

--- a/src/FunFair.CodeAnalysis.Tests/TestClassAnalysisDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/TestClassAnalysisDiagnosticsAnalyzerTests.cs
@@ -1,11 +1,9 @@
 ﻿using System.Threading.Tasks;
 using FunFair.CodeAnalysis.Tests.Helpers;
 using FunFair.CodeAnalysis.Tests.Verifiers;
-using FunFair.Test.Common;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace FunFair.CodeAnalysis.Tests
 {
@@ -27,10 +25,7 @@ namespace FunFair.CodeAnalysis.Tests
             }
 }";
 
-            MetadataReference xunitReference = MetadataReference.CreateFromFile(typeof(FactAttribute).Assembly.Location);
-            MetadataReference ffTestReference = MetadataReference.CreateFromFile(typeof(TestBase).Assembly.Location);
-
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {xunitReference, ffTestReference});
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Xunit, WellKnownMetadataReferences.FunFairTestCommon});
         }
 
         [Fact]
@@ -54,9 +49,7 @@ using Xunit;
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 6, column: 13)}
                                         };
 
-            MetadataReference xunitReference = MetadataReference.CreateFromFile(typeof(FactAttribute).Assembly.Location);
-
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {xunitReference}, expected);
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Xunit}, expected);
         }
 
         [Fact]
@@ -79,12 +72,9 @@ using Xunit.Abstractions;
             {
             }
 }";
-            
-            MetadataReference xunitAbstractionsReference = MetadataReference.CreateFromFile(typeof(ITestOutputHelper).Assembly.Location);
-            MetadataReference xunitReference = MetadataReference.CreateFromFile(typeof(FactAttribute).Assembly.Location);
-            MetadataReference ffTestReference = MetadataReference.CreateFromFile(typeof(LoggingTestBase).Assembly.Location);
 
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {xunitReference, ffTestReference, xunitAbstractionsReference});
+            return this.VerifyCSharpDiagnosticAsync(source: test,
+                                                    new[] {WellKnownMetadataReferences.Xunit, WellKnownMetadataReferences.FunFairTestCommon, WellKnownMetadataReferences.XunitAbstractions});
         }
 
         [Fact]
@@ -101,10 +91,8 @@ using Xunit;
             {
             }
 }";
-            MetadataReference xunitReference = MetadataReference.CreateFromFile(typeof(FactAttribute).Assembly.Location);
-            MetadataReference ffTestReference = MetadataReference.CreateFromFile(typeof(TestBase).Assembly.Location);
 
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {xunitReference, ffTestReference});
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Xunit, WellKnownMetadataReferences.FunFairTestCommon});
         }
 
         [Fact]
@@ -129,9 +117,7 @@ using Xunit;
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 6, column: 13)}
                                         };
 
-            MetadataReference xunitReference = MetadataReference.CreateFromFile(typeof(FactAttribute).Assembly.Location);
-
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {xunitReference}, expected);
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Xunit}, expected);
         }
 
         [Fact]
@@ -156,11 +142,8 @@ using Xunit.Abstractions;
             }
 }";
 
-            MetadataReference xunitAbstractionsReference = MetadataReference.CreateFromFile(typeof(ITestOutputHelper).Assembly.Location);
-            MetadataReference xunitReference = MetadataReference.CreateFromFile(typeof(FactAttribute).Assembly.Location);
-            MetadataReference ffTestReference = MetadataReference.CreateFromFile(typeof(LoggingTestBase).Assembly.Location);
-
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {xunitReference, ffTestReference, xunitAbstractionsReference});
+            return this.VerifyCSharpDiagnosticAsync(source: test,
+                                                    new[] {WellKnownMetadataReferences.Xunit, WellKnownMetadataReferences.FunFairTestCommon, WellKnownMetadataReferences.XunitAbstractions});
         }
 
         [Fact]
@@ -178,10 +161,8 @@ using Xunit;
             {
             }
 }";
-            MetadataReference xunitReference = MetadataReference.CreateFromFile(typeof(FactAttribute).Assembly.Location);
-            MetadataReference ffTestReference = MetadataReference.CreateFromFile(typeof(TestBase).Assembly.Location);
 
-            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {xunitReference, ffTestReference});
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Xunit, WellKnownMetadataReferences.FunFairTestCommon});
         }
     }
 }

--- a/src/FunFair.CodeAnalysis.Tests/Verifiers/CodeFixVerifier.cs
+++ b/src/FunFair.CodeAnalysis.Tests/Verifiers/CodeFixVerifier.cs
@@ -97,10 +97,7 @@ namespace FunFair.CodeAnalysis.Tests.Verifiers
             for (int i = 0; i < attempts; ++i)
             {
                 List<CodeAction> actions = new List<CodeAction>();
-                CodeFixContext context = new CodeFixContext(document: document,
-                                                            analyzerDiagnostics[0],
-                                                            registerCodeFix: (a, d) => actions.Add(a),
-                                                            cancellationToken: CancellationToken.None);
+                CodeFixContext context = new CodeFixContext(document: document, analyzerDiagnostics[0], registerCodeFix: (a, d) => actions.Add(a), cancellationToken: CancellationToken.None);
                 await codeFixProvider.RegisterCodeFixesAsync(context);
 
                 if (!actions.Any())
@@ -124,9 +121,7 @@ namespace FunFair.CodeAnalysis.Tests.Verifiers
                 if (!allowNewCompilerDiagnostics && newCompilerDiagnostics.Any())
                 {
                     // Format and get the compiler diagnostics again so that the locations make sense in the output
-                    document = document.WithSyntaxRoot(Formatter.Format(await document.GetSyntaxRootAsync(),
-                                                                        annotation: Formatter.Annotation,
-                                                                        workspace: document.Project.Solution.Workspace));
+                    document = document.WithSyntaxRoot(Formatter.Format(await document.GetSyntaxRootAsync(), annotation: Formatter.Annotation, workspace: document.Project.Solution.Workspace));
 
                     newCompilerDiagnostics = GetNewDiagnostics(diagnostics: compilerDiagnostics, await GetCompilerDiagnosticsAsync(document));
 

--- a/src/FunFair.CodeAnalysis.Tests/Verifiers/DiagnosticVerifier.Helper.cs
+++ b/src/FunFair.CodeAnalysis.Tests/Verifiers/DiagnosticVerifier.Helper.cs
@@ -26,8 +26,8 @@ namespace FunFair.CodeAnalysis.Tests.Verifiers
         private static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
         private static readonly MetadataReference CSharpSymbolsReference = MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location);
         private static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
-        private static readonly MetadataReference SystemRuntimeReference = MetadataReference.CreateFromFile(Path.Combine(path1: AssemblyPath ?? string.Empty, path2: "System.Runtime.dll"));
-        private static readonly MetadataReference SystemReference = MetadataReference.CreateFromFile(Path.Combine(path1: AssemblyPath ?? string.Empty, path2: "System.dll"));
+        private static readonly MetadataReference SystemRuntimeReference = MetadataReference.CreateFromFile(Path.Combine(AssemblyPath ?? string.Empty, path2: "System.Runtime.dll"));
+        private static readonly MetadataReference SystemReference = MetadataReference.CreateFromFile(Path.Combine(AssemblyPath ?? string.Empty, path2: "System.dll"));
         private static readonly MetadataReference SystemConsoleReference = MetadataReference.CreateFromFile(typeof(Console).Assembly.Location);
 
         internal static string DefaultFilePathPrefix = "Test";

--- a/src/FunFair.CodeAnalysis.Tests/Verifiers/DiagnosticVerifier.cs
+++ b/src/FunFair.CodeAnalysis.Tests/Verifiers/DiagnosticVerifier.cs
@@ -52,8 +52,7 @@ namespace FunFair.CodeAnalysis.Tests.Verifiers
                         }
                         else
                         {
-                            Assert.True(condition: location.IsInSource,
-                                        $"Test base does not currently handle diagnostics in metadata locations. Diagnostic in metadata: {diagnostics[i]}\r\n");
+                            Assert.True(condition: location.IsInSource, $"Test base does not currently handle diagnostics in metadata locations. Diagnostic in metadata: {diagnostics[i]}\r\n");
 
                             string resultMethodName = diagnostics[i]
                                                       .Location.SourceTree!.FilePath.EndsWith(value: ".cs", comparisonType: StringComparison.OrdinalIgnoreCase)
@@ -165,11 +164,7 @@ namespace FunFair.CodeAnalysis.Tests.Verifiers
         /// <param name="language">The language of the classes represented by the source strings</param>
         /// <param name="analyzer">The analyzer to be run on the source code</param>
         /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
-        private static async Task VerifyDiagnosticsAsync(string[] sources,
-                                                         MetadataReference[] references,
-                                                         string language,
-                                                         DiagnosticAnalyzer analyzer,
-                                                         params DiagnosticResult[] expected)
+        private static async Task VerifyDiagnosticsAsync(string[] sources, MetadataReference[] references, string language, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expected)
         {
             Diagnostic[] diagnostics = await GetSortedDiagnosticsAsync(sources: sources, references: references, language: language, analyzer: analyzer);
 
@@ -212,8 +207,7 @@ namespace FunFair.CodeAnalysis.Tests.Verifiers
                 {
                     if (actual.Location != Location.None)
                     {
-                        Assert.True(condition: false,
-                                    string.Format(format: "Expected:\nA project diagnostic with No location\nActual:\n{0}", FormatDiagnostics(analyzer: analyzer, actual)));
+                        Assert.True(condition: false, string.Format(format: "Expected:\nA project diagnostic with No location\nActual:\n{0}", FormatDiagnostics(analyzer: analyzer, actual)));
                     }
                 }
                 else

--- a/src/FunFair.CodeAnalysis/ForceMethodParametersInvocationsDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ForceMethodParametersInvocationsDiagnosticsAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿﻿using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using FunFair.CodeAnalysis.Helpers;

--- a/src/FunFair.CodeAnalysis/Helpers/ItemHelpers.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/ItemHelpers.cs
@@ -5,7 +5,7 @@ namespace FunFair.CodeAnalysis.Helpers
     /// <summary>
     ///     Item helpers
     /// </summary>
-    public static class ItemHelpers
+    internal static class ItemHelpers
     {
         /// <summary>
         ///     Removes nulls from the source collection.

--- a/src/FunFair.CodeAnalysis/Helpers/Mapping.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/Mapping.cs
@@ -5,7 +5,7 @@ namespace FunFair.CodeAnalysis.Helpers
     /// <summary>
     ///     Mapping class
     /// </summary>
-    public sealed class Mapping : IEquatable<Mapping>
+    internal sealed class Mapping : IEquatable<Mapping>
     {
         /// <summary>
         ///     Constructor

--- a/src/FunFair.CodeAnalysis/Helpers/MethodSymbolHelper.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/MethodSymbolHelper.cs
@@ -7,7 +7,7 @@ namespace FunFair.CodeAnalysis.Helpers
     /// <summary>
     ///     Method symbol helper
     /// </summary>
-    public static class MethodSymbolHelper
+    internal static class MethodSymbolHelper
     {
         /// <summary>
         ///     Find invoked member symbol

--- a/src/FunFair.CodeAnalysis/Helpers/ParameterHelpers.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/ParameterHelpers.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FunFair.CodeAnalysis.Helpers
+{
+    internal static class ParameterHelpers
+    {
+        public static string? GetFullTypeName(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext, ParameterSyntax parameterSyntax)
+        {
+            IParameterSymbol? ds = syntaxNodeAnalysisContext.SemanticModel.GetDeclaredSymbol(parameterSyntax);
+
+            if (ds != null)
+            {
+                ITypeSymbol typeSymbol = GetTypeSymbol(ds);
+
+                return typeSymbol.ToDisplayString();
+            }
+
+            return null;
+        }
+
+        private static ITypeSymbol GetTypeSymbol(IParameterSymbol ds)
+        {
+            ITypeSymbol dsType = ds.Type;
+
+            if (dsType is INamedTypeSymbol nts && nts.IsGenericType)
+            {
+                dsType = dsType.OriginalDefinition;
+            }
+
+            return dsType;
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/Helpers/Rules.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/Rules.cs
@@ -21,5 +21,6 @@ namespace FunFair.CodeAnalysis.Helpers
         public const string RuleMustPassInterExceptionToExceptionsThrownInCatchBlock = @"FFS0017";
         public const string RuleDontUseSubstituteReceivedWithoutAmountOfCalls = @"FFS0018";
         public const string RuleLoggerParametersShouldBeCalledLogger = @"FFS0019";
+        public const string RuleParametersShouldBeInOrder = @"FFS0020";
     }
 }

--- a/src/FunFair.CodeAnalysis/ParameterOrderingDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ParameterOrderingDiagnosticsAnalyzer.cs
@@ -70,7 +70,7 @@ namespace FunFair.CodeAnalysis
                     {
                         matchedEndings.Add(parameterType);
 
-                        int parameterIndex = parameters.Length - matchingParameter.Index;
+                        int parameterIndex = matchingParameter.Index;
                         int requiredParameterIndex = parameters.Length - matchedEndings.Count;
 
                         if (parameterIndex != requiredParameterIndex)

--- a/src/FunFair.CodeAnalysis/ParameterOrderingDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ParameterOrderingDiagnosticsAnalyzer.cs
@@ -68,6 +68,12 @@ namespace FunFair.CodeAnalysis
 
                     if (matchingParameter != null)
                     {
+                        if (matchingParameter.Parameter.Modifiers.Any(pm => pm.Kind() == SyntaxKind.ThisKeyword))
+                        {
+                            // Ignore parameters that are extension methods - they have to be the first parameter
+                            continue;
+                        }
+
                         matchedEndings.Add(parameterType);
 
                         int parameterIndex = matchingParameter.Index;

--- a/src/FunFair.CodeAnalysis/ParameterOrderingDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ParameterOrderingDiagnosticsAnalyzer.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using FunFair.CodeAnalysis.Helpers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FunFair.CodeAnalysis
+{
+    /// <summary>
+    ///     Looks for issues with parameter ordering
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class ParameterOrderingDiagnosticsAnalyzer : DiagnosticAnalyzer
+    {
+        private const string CATEGORY = "Parameters";
+
+        private static readonly IReadOnlyList<string> PreferredEndingOrdering = new[]
+                                                                                {
+                                                                                    "Microsoft.Extensions.Logging.ILogger<TCategoryName>",
+                                                                                    "Microsoft.Extensions.Logging.ILogger",
+                                                                                    "System.Threading.CancellationToken"
+                                                                                };
+
+        private static readonly DiagnosticDescriptor Rule = RuleHelpers.CreateRule(code: Rules.RuleParametersShouldBeInOrder,
+                                                                                   category: CATEGORY,
+                                                                                   title: "Parameters are out of order",
+                                                                                   message: "Parameter {0} must be the {1} parameter");
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => new[] {Rule}.ToImmutableArray();
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterCompilationStartAction(this.PerformCheck);
+        }
+
+        private void PerformCheck(CompilationStartAnalysisContext compilationStartContext)
+        {
+            compilationStartContext.RegisterSyntaxNodeAction(action: this.MustBeInASaneOrder, SyntaxKind.ParameterList);
+        }
+
+        private void MustBeInASaneOrder(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
+        {
+            if (syntaxNodeAnalysisContext.Node is ParameterListSyntax parameterList)
+            {
+                var parameters = parameterList.Parameters.Select((parameter, index) => new
+                                                                                       {
+                                                                                           Parameter = parameter,
+                                                                                           Index = index,
+                                                                                           FullTypeName = ParameterHelpers.GetFullTypeName(
+                                                                                               syntaxNodeAnalysisContext: syntaxNodeAnalysisContext,
+                                                                                               parameterSyntax: parameter)
+                                                                                       })
+                                              .ToArray();
+
+                List<string> matchedEndings = new List<string>();
+
+                foreach (var parameterType in PreferredEndingOrdering.Reverse())
+                {
+                    var matchingParameter = parameters.FirstOrDefault(x => x.FullTypeName == parameterType);
+
+                    if (matchingParameter != null)
+                    {
+                        matchedEndings.Add(parameterType);
+
+                        int parameterIndex = parameters.Length - matchingParameter.Index;
+                        int requiredParameterIndex = parameters.Length - matchedEndings.Count;
+
+                        if (parameterIndex != requiredParameterIndex)
+                        {
+                            syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(descriptor: Rule,
+                                                                                         matchingParameter.Parameter.GetLocation(),
+                                                                                         matchingParameter.Parameter.Identifier.Text,
+                                                                                         requiredParameterIndex));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/ParameterOrderingDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ParameterOrderingDiagnosticsAnalyzer.cs
@@ -27,7 +27,7 @@ namespace FunFair.CodeAnalysis
         private static readonly DiagnosticDescriptor Rule = RuleHelpers.CreateRule(code: Rules.RuleParametersShouldBeInOrder,
                                                                                    category: CATEGORY,
                                                                                    title: "Parameters are out of order",
-                                                                                   message: "Parameter {0} must be the {1} parameter");
+                                                                                   message: "Parameter '{0}' must be parameter {1}");
 
         /// <inheritdoc />
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => new[] {Rule}.ToImmutableArray();
@@ -78,7 +78,7 @@ namespace FunFair.CodeAnalysis
                             syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(descriptor: Rule,
                                                                                          matchingParameter.Parameter.GetLocation(),
                                                                                          matchingParameter.Parameter.Identifier.Text,
-                                                                                         requiredParameterIndex));
+                                                                                         requiredParameterIndex + 1));
                         }
                     }
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue\Feature

<!--- Please link to the issue or feature: -->

## How Has This Been Tested

- [x] All unit tests pass.
- [ ] All integration tests pass.
- [ ] Manual Testing: 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

<!--- Insert Deployment configuration changes here -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes once they are true. -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [x] There are no Resharper\static code analysis errors anywhere in the solution.
- [x] I have run a code clean-up on any files I have modified to make sure they are in the correct format.
- [x] I have added tests to cover my changes.
- [x] I have run the code and quickly verified it all works to my satisfaction.
- [x] All new/modified code has sufficient logging to be able to diagnose what is wrong.
- [x] All new and existing tests passed.
- [x] All new/modified public interfaces/classes have are documented with xmldoc comments.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.
