### PR TITLE
Force usage of NonBlocking dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Added
+- Check if NonBlocking dictionary is used
 ### Fixed
 ### Changed
 ### Removed

--- a/src/FunFair.CodeAnalysis.Tests/FunFair.CodeAnalysis.Tests.csproj
+++ b/src/FunFair.CodeAnalysis.Tests/FunFair.CodeAnalysis.Tests.csproj
@@ -27,6 +27,7 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+        <PackageReference Include="NonBlocking" Version="1.1.2" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/src/FunFair.CodeAnalysis.Tests/Helpers/WellKnownMetadataReferences.cs
+++ b/src/FunFair.CodeAnalysis.Tests/Helpers/WellKnownMetadataReferences.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Text.Json;
@@ -39,5 +40,9 @@ namespace FunFair.CodeAnalysis.Tests.Helpers
         public static readonly MetadataReference ConnectionInfo = MetadataReference.CreateFromFile(typeof(ConnectionInfo).Assembly.Location);
 
         public static readonly MetadataReference SuppressMessage = MetadataReference.CreateFromFile(typeof(SuppressMessageAttribute).Assembly.Location);
+
+        public static readonly MetadataReference ConcurrentDictionary  = MetadataReference.CreateFromFile(typeof(ConcurrentDictionary<int,int>).Assembly.Location);
+
+        public static readonly MetadataReference NonBlockingConcurrentDictionary  = MetadataReference.CreateFromFile(typeof(NonBlocking.ConcurrentDictionary<int,int>).Assembly.Location);
     }
 }

--- a/src/FunFair.CodeAnalysis.Tests/Helpers/WellKnownMetadataReferences.cs
+++ b/src/FunFair.CodeAnalysis.Tests/Helpers/WellKnownMetadataReferences.cs
@@ -43,6 +43,6 @@ namespace FunFair.CodeAnalysis.Tests.Helpers
 
         public static readonly MetadataReference ConcurrentDictionary  = MetadataReference.CreateFromFile(typeof(ConcurrentDictionary<int,int>).Assembly.Location);
 
-        public static readonly MetadataReference NonBlockingConcurrentDictionary  = MetadataReference.CreateFromFile(typeof(NonBlocking.ConcurrentDictionary<int,int>).Assembly.Location);
+        public static readonly MetadataReference NonBlockingConcurrentDictionary  = MetadataReference.CreateFromFile(typeof(NonBlocking.ConcurrentDictionary<,>).Assembly.Location);
     }
 }

--- a/src/FunFair.CodeAnalysis.Tests/ProhibitedClassesDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ProhibitedClassesDiagnosticsAnalyzerTests.cs
@@ -15,7 +15,7 @@ namespace FunFair.CodeAnalysis.Tests
         }
 
         [Fact]
-        public Task AssertFalseWithMessageIsAllowedAsync()
+        public Task AssertFalseForNonBlockingConcurrentDictionaryAsync()
         {
             const string test = @"
      using NonBlocking;
@@ -151,6 +151,33 @@ namespace FunFair.CodeAnalysis.Tests
                                             Message = @"Use NonBlocking.ConcurrentDictionary  rather than System.Collections.Concurrent.ConcurrentDictionary",
                                             Severity = DiagnosticSeverity.Error,
                                             Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 8, column: 13)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.ConcurrentDictionary}, expected);
+        }
+
+        [Fact]
+        public Task AssertTrueForParameterInConstructorDeclarationWithMessageIsBannedAsync()
+        {
+            const string test = @"
+     using System.Collections.Concurrent;
+
+     namespace ConsoleApplication1
+     {
+         class TypeName
+         {
+             public TypeName(ConcurrentDictionary<int,int> dictionary)
+             {
+
+             }
+         }
+     }";
+            DiagnosticResult expected = new()
+                                        {
+                                            Id = "FFS0031",
+                                            Message = @"Use NonBlocking.ConcurrentDictionary  rather than System.Collections.Concurrent.ConcurrentDictionary",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 8, column: 14)}
                                         };
 
             return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.ConcurrentDictionary}, expected);

--- a/src/FunFair.CodeAnalysis.Tests/ProhibitedClassesDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ProhibitedClassesDiagnosticsAnalyzerTests.cs
@@ -1,0 +1,159 @@
+using System.Threading.Tasks;
+using FunFair.CodeAnalysis.Tests.Helpers;
+using FunFair.CodeAnalysis.Tests.Verifiers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace FunFair.CodeAnalysis.Tests
+{
+    public sealed class ProhibitedClassesDiagnosticsAnalyzerTests : CodeFixVerifier
+    {
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new ProhibitedClassesDiagnosticsAnalyzer();
+        }
+
+        [Fact]
+        public Task AssertFalseWithMessageIsAllowedAsync()
+        {
+            const string test = @"
+     using NonBlocking;
+
+     namespace ConsoleApplication1
+     {
+         class TypeName
+         {
+             void Test()
+             {
+                 ConcurrentDictionary<int,int> dictionary = new ConcurrentDictionary<int,int>();
+             }
+         }
+     }";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.NonBlockingConcurrentDictionary});
+        }
+
+        [Fact]
+        public Task AssertTrueForCreationOfNewInstanceWithMessageIsBannedAsync()
+        {
+            const string test = @"
+     using System.Collections.Concurrent;
+
+     namespace ConsoleApplication1
+     {
+         class TypeName
+         {
+             void Test()
+             {
+                 ConcurrentDictionary<int,int> dictionary = new ConcurrentDictionary<int,int>();
+             }
+         }
+     }";
+            DiagnosticResult expected = new()
+                                        {
+                                            Id = "FFS0031",
+                                            Message = @"Use NonBlocking.ConcurrentDictionary  rather than System.Collections.Concurrent.ConcurrentDictionary",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 10, column: 61)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.ConcurrentDictionary}, expected);
+        }
+
+        [Fact]
+        public Task AssertTrueForParameterInMethodDeclarationWithMessageIsBannedAsync()
+        {
+            const string test = @"
+     using System.Collections.Concurrent;
+
+     namespace ConsoleApplication1
+     {
+         class TypeName
+         {
+             void Test(ConcurrentDictionary<int,int> dictionary)
+             {
+
+             }
+         }
+     }";
+            DiagnosticResult expected = new()
+                                        {
+                                            Id = "FFS0031",
+                                            Message = @"Use NonBlocking.ConcurrentDictionary  rather than System.Collections.Concurrent.ConcurrentDictionary",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 8, column: 14)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.ConcurrentDictionary}, expected);
+        }
+
+        [Fact]
+        public Task AssertTrueForFieldDeclarationMessageIsBannedAsync()
+        {
+            const string test = @"
+     using System.Collections.Concurrent;
+
+     namespace ConsoleApplication1
+     {
+         class TypeName
+         {
+             private ConcurrentDictionary<int,int> dictionary;
+
+             void Test()
+             {
+                this.dictionary = new ConcurrentDictionary<int,int>();
+             }
+         }
+     }";
+            DiagnosticResult[] expected =
+            {
+                new()
+                {
+                    Id = "FFS0031",
+                    Message = @"Use NonBlocking.ConcurrentDictionary  rather than System.Collections.Concurrent.ConcurrentDictionary",
+                    Severity = DiagnosticSeverity.Error,
+                    Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 8, column: 52)}
+                },
+                new()
+                {
+                    Id = "FFS0031",
+                    Message = @"Use NonBlocking.ConcurrentDictionary  rather than System.Collections.Concurrent.ConcurrentDictionary",
+                    Severity = DiagnosticSeverity.Error,
+                    Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 12, column: 35)}
+                }
+            };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.ConcurrentDictionary}, expected: expected);
+        }
+
+        [Fact]
+        public Task AssertTrueForPropertyDeclarationMessageIsBannedAsync()
+        {
+            const string test = @"
+     using System.Collections.Concurrent;
+
+     namespace ConsoleApplication1
+     {
+         class TypeName
+         {
+            public ConcurrentDictionary<int,int> Dictionary {get; private set;}
+
+             void Test()
+             {
+
+             }
+         }
+     }";
+            DiagnosticResult expected = new()
+                                        {
+                                            Id = "FFS0031",
+                                            Message = @"Use NonBlocking.ConcurrentDictionary  rather than System.Collections.Concurrent.ConcurrentDictionary",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 8, column: 13)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.ConcurrentDictionary}, expected);
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/Helpers/Rules.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/Rules.cs
@@ -32,5 +32,6 @@ namespace FunFair.CodeAnalysis.Helpers
         public const string RuleRecordsShouldBeSealed = @"FFS0028";
         public const string MockBaseClassInstancesMustBeInternal = @"FFS0029";
         public const string MockBaseClassInstancesMustBeSealed = @"FFS0030";
+        public const string RuleDontUseConcurrentDictionary = @"FFS0031";
     }
 }

--- a/src/FunFair.CodeAnalysis/Helpers/TypeSymbolHelpers.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/TypeSymbolHelpers.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace FunFair.CodeAnalysis.Helpers
+{
+    internal static class TypeSymbolHelpers
+    {
+        public static string ToFullyQualifiedName(this ITypeSymbol symbol)
+        {
+            string nameSpace = symbol.OriginalDefinition.ContainingNamespace.ToDisplayString();
+
+            return $"{nameSpace}.{symbol.OriginalDefinition.MetadataName}";
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/ProhibitedClassesDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ProhibitedClassesDiagnosticsAnalyzer.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using FunFair.CodeAnalysis.Helpers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FunFair.CodeAnalysis
+{
+    /// <inheritdoc />
+    /// <summary>
+    ///     Looks for prohibited classes.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class ProhibitedClassesDiagnosticsAnalyzer : DiagnosticAnalyzer
+    {
+        private const string CATEGORY = "Illegal Class Usage";
+
+        private static readonly ProhibitedClassSpec[] BannedClasses =
+        {
+            new(ruleId: Rules.RuleDontUseConcurrentDictionary, title: "Avoid use of System.Collections.Concurrent.ConcurrentDictionary class", message:
+                "Use NonBlocking.ConcurrentDictionary  rather than System.Collections.Concurrent.ConcurrentDictionary", sourceClass: "System.Collections.Concurrent.ConcurrentDictionary`2"),
+        };
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            BannedClasses.Select(selector: r => r.Rule)
+                         .ToImmutableArray();
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterCompilationStartAction(PerformCheck);
+        }
+
+        private static void PerformCheck(CompilationStartAnalysisContext compilationStartContext)
+        {
+            void LookForBannedClasses(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
+            {
+                Dictionary<string, INamedTypeSymbol> cachedSymbols = BuildCachedSymbols(compilationStartContext.Compilation);
+                IEnumerable<INamedTypeSymbol>? typeSymbols = LookForUsageOfBannedClasses(syntaxNodeAnalysisContext: syntaxNodeAnalysisContext, cachedSymbols: cachedSymbols);
+
+                if (typeSymbols == null)
+                {
+                    return;
+                }
+
+                ReportAnyBannedSymbols(typeSymbols.ToList(), syntaxNodeAnalysisContext: syntaxNodeAnalysisContext);
+            }
+
+            compilationStartContext.RegisterSyntaxNodeAction(action: LookForBannedClasses, SyntaxKind.ObjectCreationExpression);
+            compilationStartContext.RegisterSyntaxNodeAction(action: LookForBannedClasses, SyntaxKind.FieldDeclaration);
+            compilationStartContext.RegisterSyntaxNodeAction(action: LookForBannedClasses, SyntaxKind.VariableDeclarator);
+            compilationStartContext.RegisterSyntaxNodeAction(action: LookForBannedClasses, SyntaxKind.MethodDeclaration);
+            compilationStartContext.RegisterSyntaxNodeAction(action: LookForBannedClasses, SyntaxKind.PropertyDeclaration);
+        }
+
+        private static void ReportAnyBannedSymbols(IReadOnlyCollection<INamedTypeSymbol> typeSymbols, SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
+        {
+            foreach (INamedTypeSymbol typeSymbol in typeSymbols)
+            {
+                ProhibitedClassSpec? bannedClass = BannedClasses.FirstOrDefault(rule => StringComparer.OrdinalIgnoreCase.Equals(x: typeSymbol.ToFullyQualifiedName(), y: rule.SourceClass));
+
+                if (bannedClass != null)
+                {
+                    syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(descriptor: bannedClass.Rule, syntaxNodeAnalysisContext.Node.GetLocation()));
+                }
+            }
+        }
+
+        private static Dictionary<string, INamedTypeSymbol> BuildCachedSymbols(Compilation compilation)
+        {
+            Dictionary<string, INamedTypeSymbol> cachedSymbols = new();
+
+            foreach (ProhibitedClassSpec rule in BannedClasses)
+            {
+                if (!cachedSymbols.ContainsKey(rule.SourceClass))
+                {
+                    INamedTypeSymbol? item = compilation.GetTypeByMetadataName(rule.SourceClass);
+
+                    if (item != null)
+                    {
+                        cachedSymbols.Add(key: rule.SourceClass, value: item);
+                    }
+                }
+            }
+
+            return cachedSymbols;
+        }
+
+        private static IEnumerable<INamedTypeSymbol>? LookForUsageOfBannedClasses(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext, Dictionary<string, INamedTypeSymbol> cachedSymbols)
+        {
+            ISymbol? symbol = syntaxNodeAnalysisContext.SemanticModel.GetDeclaredSymbol(syntaxNodeAnalysisContext.Node);
+
+            if (symbol != null)
+            {
+                switch (symbol.OriginalDefinition)
+                {
+                    case IPropertySymbol propertySymbol: return GetSymbol(new[] {propertySymbol.Type}, cachedSymbols: cachedSymbols);
+                    case IFieldSymbol fieldSymbol: return GetSymbol(new[] {fieldSymbol.Type}, cachedSymbols: cachedSymbols);
+                    case IMethodSymbol parameterSymbol: return GetSymbol(parameterSymbol.Parameters.Select(x => x.Type), cachedSymbols: cachedSymbols);
+                }
+            }
+
+            ITypeSymbol? typeInfo = syntaxNodeAnalysisContext.SemanticModel.GetTypeInfo(syntaxNodeAnalysisContext.Node)
+                                                             .Type;
+
+            if (typeInfo != null)
+            {
+                return GetSymbol(new[] {typeInfo}, cachedSymbols: cachedSymbols);
+            }
+
+            return null;
+        }
+
+        private static IEnumerable<INamedTypeSymbol> GetSymbol(IEnumerable<ITypeSymbol> symbols, Dictionary<string, INamedTypeSymbol> cachedSymbols)
+        {
+            return symbols.Select(symbol => GetSymbol(symbol: symbol, cachedSymbols: cachedSymbols))
+                          .Where(symbol => symbol != null)!;
+        }
+
+        /// <summary>
+        ///     Get symbol from list of defined banned classes
+        /// </summary>
+        /// <param name="symbol">Symbol to get</param>
+        /// <param name="cachedSymbols">The symbol cache</param>
+        /// <returns></returns>
+        private static INamedTypeSymbol? GetSymbol(ITypeSymbol symbol, Dictionary<string, INamedTypeSymbol> cachedSymbols)
+        {
+            string typeName = symbol.ToFullyQualifiedName();
+
+            if (cachedSymbols.ContainsKey(typeName))
+            {
+                return cachedSymbols[typeName];
+            }
+
+            return null;
+        }
+
+        private sealed class ProhibitedClassSpec
+        {
+            public ProhibitedClassSpec(string ruleId, string title, string message, string sourceClass)
+            {
+                this.SourceClass = sourceClass;
+                this.Rule = RuleHelpers.CreateRule(code: ruleId, category: CATEGORY, title: title, message: message);
+            }
+
+            public string SourceClass { get; }
+
+            public DiagnosticDescriptor Rule { get; }
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/ProhibitedClassesDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ProhibitedClassesDiagnosticsAnalyzer.cs
@@ -58,13 +58,14 @@ namespace FunFair.CodeAnalysis
             compilationStartContext.RegisterSyntaxNodeAction(action: LookForBannedClasses, SyntaxKind.VariableDeclarator);
             compilationStartContext.RegisterSyntaxNodeAction(action: LookForBannedClasses, SyntaxKind.MethodDeclaration);
             compilationStartContext.RegisterSyntaxNodeAction(action: LookForBannedClasses, SyntaxKind.PropertyDeclaration);
+            compilationStartContext.RegisterSyntaxNodeAction(action: LookForBannedClasses, SyntaxKind.ConstructorDeclaration);
         }
 
         private static void ReportAnyBannedSymbols(IReadOnlyCollection<INamedTypeSymbol> typeSymbols, SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
         {
             foreach (INamedTypeSymbol typeSymbol in typeSymbols)
             {
-                ProhibitedClassSpec? bannedClass = BannedClasses.FirstOrDefault(rule => StringComparer.OrdinalIgnoreCase.Equals(x: typeSymbol.ToFullyQualifiedName(), y: rule.SourceClass));
+                ProhibitedClassSpec? bannedClass = BannedClasses.FirstOrDefault(rule => StringComparer.OrdinalIgnoreCase.Equals(typeSymbol.ToFullyQualifiedName(), y: rule.SourceClass));
 
                 if (bannedClass != null)
                 {
@@ -120,26 +121,21 @@ namespace FunFair.CodeAnalysis
 
         private static IEnumerable<INamedTypeSymbol> GetSymbol(IEnumerable<ITypeSymbol> symbols, Dictionary<string, INamedTypeSymbol> cachedSymbols)
         {
-            return symbols.Select(symbol => GetSymbol(symbol: symbol, cachedSymbols: cachedSymbols))
+            return symbols.Select(symbol => GetSymbol(typeSymbol: symbol, cachedSymbols: cachedSymbols))
                           .Where(symbol => symbol != null)!;
         }
 
         /// <summary>
         ///     Get symbol from list of defined banned classes
         /// </summary>
-        /// <param name="symbol">Symbol to get</param>
+        /// <param name="typeSymbol">Type symbol to get</param>
         /// <param name="cachedSymbols">The symbol cache</param>
         /// <returns></returns>
-        private static INamedTypeSymbol? GetSymbol(ITypeSymbol symbol, Dictionary<string, INamedTypeSymbol> cachedSymbols)
+        private static INamedTypeSymbol? GetSymbol(ITypeSymbol typeSymbol, Dictionary<string, INamedTypeSymbol> cachedSymbols)
         {
-            string typeName = symbol.ToFullyQualifiedName();
+            string typeName = typeSymbol.ToFullyQualifiedName();
 
-            if (cachedSymbols.ContainsKey(typeName))
-            {
-                return cachedSymbols[typeName];
-            }
-
-            return null;
+            return cachedSymbols.TryGetValue(key: typeName, out INamedTypeSymbol? symbol) ? symbol : null;
         }
 
         private sealed class ProhibitedClassSpec


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above that includes the Jira Ticket -->
Force usage of NonBlocking dictionary
# Description
<!--- Describe your changes in detail -->

# Related Issue\Feature

<!--- Please link to the issue or feature: -->

# How Has This Been Tested

- [ ] All unit tests pass.
- [ ] All integration tests pass.
- [ ] Manual Testing:
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Types of changes

<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Removed no-longer used code

## Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

<!--- Insert Deployment configuration changes here -->

# Checklist

<!--- Go over all the following points, and put an 'x' in all the boxes once they are true. -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] There are no Resharper\static code analysis errors anywhere in the solution.
- [ ] I have ONLY run a code clean-up on any files I have modified to make sure they are in the correct format and no others.
- [x] I have added tests to cover my changes.
- [ ] I have run the code and quickly verified it all works to my satisfaction.
- [ ] All new/modified code has sufficient logging to be able to diagnose what is wrong.
- [x] All new and existing tests passed.
- [ ] All new/modified public interfaces/classes have are documented with xmldoc comments.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.
