### PR TITLE
Block built-in methods for NonBlocking concurrent dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Added
+- Check if built-in methods are used for NonBlocking.ConcurrentDictionary<,> and force usage of extension methods under FunFair.Common.Extensions.ConcurrentDictionaryExtensions
 ### Fixed
 ### Changed
 - FF-1429 - Updated TeamCity.VSTest.TestAdapter to 1.0.26

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Static Code analysis Repo for FunFair Server dotnet projects.
 |FFS0029|Classes derived from ``MockBase<T>`` should be ``internal``|
 |FFS0030|Classes derived from ``MockBase<T>`` should be ``sealed``|
 |FFS0031|Avoid using ``System.Collections.Concurrent.ConcurrentDictionary<,>`` - Use ``NonBlocking.ConcurrentDictionary<,>``|
+|FFS0032|Avoid using ``NonBlocing.ConcurrentDictionary<,>.AddOrUpdate`` - Use ``FunFair.Common.Extensions.ConcurrentDictionaryExtensions.AddOrUpdate``|
+|FFS0033|Avoid using ``NonBlocing.ConcurrentDictionary<,>.GetOrAdd`` - Use ``FunFair.Common.Extensions.ConcurrentDictionaryExtensions.GetOrAdd``|
 
 
 ## Changelog

--- a/src/.idea/.idea.FunFair.CodeAnalysis/.idea/aws.xml
+++ b/src/.idea/.idea.FunFair.CodeAnalysis/.idea/aws.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="accountSettings">
+    <option name="activeProfile" value="profile:default" />
+    <option name="activeRegion" value="us-east-1" />
+    <option name="recentlyUsedProfiles">
+      <list>
+        <option value="profile:default" />
+      </list>
+    </option>
+    <option name="recentlyUsedRegions">
+      <list>
+        <option value="us-east-1" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/src/FunFair.CodeAnalysis.Tests/Helpers/WellKnownMetadataReferences.cs
+++ b/src/FunFair.CodeAnalysis.Tests/Helpers/WellKnownMetadataReferences.cs
@@ -41,8 +41,8 @@ namespace FunFair.CodeAnalysis.Tests.Helpers
 
         public static readonly MetadataReference SuppressMessage = MetadataReference.CreateFromFile(typeof(SuppressMessageAttribute).Assembly.Location);
 
-        public static readonly MetadataReference ConcurrentDictionary  = MetadataReference.CreateFromFile(typeof(ConcurrentDictionary<,>).Assembly.Location);
+        public static readonly MetadataReference ConcurrentDictionary = MetadataReference.CreateFromFile(typeof(ConcurrentDictionary<,>).Assembly.Location);
 
-        public static readonly MetadataReference NonBlockingConcurrentDictionary  = MetadataReference.CreateFromFile(typeof(NonBlocking.ConcurrentDictionary<,>).Assembly.Location);
+        public static readonly MetadataReference NonBlockingConcurrentDictionary = MetadataReference.CreateFromFile(typeof(NonBlocking.ConcurrentDictionary<,>).Assembly.Location);
     }
 }

--- a/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodInvocationsDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodInvocationsDiagnosticsAnalyzerTests.cs
@@ -109,5 +109,172 @@ namespace FunFair.CodeAnalysis.Tests
 
             return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Assert}, expected);
         }
+
+        [Fact]
+        public Task ShouldRaiseErrorForAddOrUpdateAsync()
+        {
+            const string test = @"
+     using NonBlocking;
+
+     namespace ConsoleApplication1
+     {
+         class TypeName
+         {
+             int Update(int x, int y){
+                return x+y+1;
+            }
+
+             void Test()
+             {
+                 ConcurrentDictionary<int,int> dictionary = new ConcurrentDictionary<int,int>();
+                 dictionary.AddOrUpdate(key: 1, addValueFactory: (x) => x + 1, updateValueFactory: this.Update);
+             }
+         }
+     }";
+            DiagnosticResult expected = new()
+                                        {
+                                            Id = "FFS0032",
+                                            Message = @"Don't use any of the built in AddOrUpdate methods, instead FunFair.Common.Extensions.ConcurrentDictionaryExtensions.AddOrUpdate can be used",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 15, column: 18)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.NonBlockingConcurrentDictionary}, expected);
+        }
+
+        [Fact]
+        public Task ShouldRaiseErrorForAddOrUpdateWithOutAddValueFactoryAsync()
+        {
+            const string test = @"
+     using NonBlocking;
+
+     namespace ConsoleApplication1
+     {
+         class TypeName
+         {
+            void Test()
+             {
+                 ConcurrentDictionary<int,int> dictionary = new ConcurrentDictionary<int,int>();
+                 dictionary.AddOrUpdate(key: 1, addValue: 1, updateValueFactory: (x, y) => x + y);
+             }
+         }
+     }";
+            DiagnosticResult expected = new()
+                                        {
+                                            Id = "FFS0032",
+                                            Message = @"Don't use any of the built in AddOrUpdate methods, instead FunFair.Common.Extensions.ConcurrentDictionaryExtensions.AddOrUpdate can be used",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 11, column: 18)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.NonBlockingConcurrentDictionary}, expected);
+        }
+
+        [Fact]
+        public Task ShouldRaiseErrorForGetOrAddAsync()
+        {
+            const string test = @"
+     using NonBlocking;
+
+     namespace ConsoleApplication1
+     {
+         class TypeName
+         {
+            void Test()
+             {
+                 ConcurrentDictionary<int,int> dictionary = new ConcurrentDictionary<int,int>();
+                 dictionary.GetOrAdd(key: 1, valueFactory: i => i);
+             }
+         }
+     }";
+            DiagnosticResult expected = new()
+                                        {
+                                            Id = "FFS0033",
+                                            Message = @"Don't use any of the built in GetOrAdd methods, instead FunFair.Common.Extensions.ConcurrentDictionaryExtensions.GetOrAdd can be used",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 11, column: 18)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.NonBlockingConcurrentDictionary}, expected);
+        }
+
+        [Fact]
+        public Task ShouldAllowAddOrUpdateAsync()
+        {
+            const string test = @"
+     using NonBlocking;
+
+     namespace ConsoleApplication1
+     {
+         class TypeName
+         {
+             int Update(int x, int y){
+                return x+y+1;
+            }
+
+            int Add(int x){
+                return x+1;
+            }
+
+             void Test()
+             {
+                 ConcurrentDictionary<int,int> dictionary = new ConcurrentDictionary<int,int>();
+                 dictionary.AddOrUpdate(key: 1, addValueFactory: this.Add, updateValueFactory: this.Update);
+             }
+         }
+     }";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.NonBlockingConcurrentDictionary});
+        }
+
+        [Fact]
+        public Task ShouldAllowAddOrUpdateWithOutAddValueFactoryAsync()
+        {
+            const string test = @"
+     using NonBlocking;
+
+     namespace ConsoleApplication1
+     {
+         class TypeName
+         {
+             int Update(int x, int y){
+                return x+y+1;
+            }
+
+             void Test()
+             {
+                 ConcurrentDictionary<int,int> dictionary = new ConcurrentDictionary<int,int>();
+                 dictionary.AddOrUpdate(key: 1, addValue: 1, updateValueFactory: this.Update);
+             }
+         }
+     }";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.NonBlockingConcurrentDictionary});
+        }
+
+        [Fact]
+        public Task ShouldAllowGetOrAddAsync()
+        {
+            const string test = @"
+     using NonBlocking;
+
+     namespace ConsoleApplication1
+     {
+         class TypeName
+         {
+             int ValueFactory(int x){
+                return x+1;
+            }
+
+             void Test()
+             {
+                 ConcurrentDictionary<int,int> dictionary = new ConcurrentDictionary<int,int>();
+                 dictionary.GetOrAdd(key: 1, valueFactory: this.ValueFactory);
+             }
+         }
+     }";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.NonBlockingConcurrentDictionary});
+        }
     }
 }

--- a/src/FunFair.CodeAnalysis/ForceMethodParametersInvocationsDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ForceMethodParametersInvocationsDiagnosticsAnalyzer.cs
@@ -72,7 +72,7 @@ namespace FunFair.CodeAnalysis
                         continue;
                     }
 
-                    Mapping mapping = new(methodName: memberSymbol.Name, SymbolDisplay.ToDisplayString(memberSymbol.ContainingType));
+                    Mapping mapping = new(SymbolDisplay.ToDisplayString(memberSymbol.ContainingType), methodName: memberSymbol.Name);
 
                     IEnumerable<ForcedMethodsSpec> forcedMethods = ForcedMethods.Where(predicate: rule => rule.QualifiedName == mapping.QualifiedName);
 

--- a/src/FunFair.CodeAnalysis/Helpers/Mapping.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/Mapping.cs
@@ -10,9 +10,9 @@ namespace FunFair.CodeAnalysis.Helpers
         /// <summary>
         ///     Constructor
         /// </summary>
-        /// <param name="methodName">Method name</param>
         /// <param name="className">Class name</param>
-        public Mapping(string methodName, string className)
+        /// <param name="methodName">Method name</param>
+        public Mapping(string className, string methodName)
         {
             this.MethodName = methodName;
             this.ClassName = className;
@@ -21,12 +21,12 @@ namespace FunFair.CodeAnalysis.Helpers
         /// <summary>
         ///     Method name
         /// </summary>
-        public string MethodName { get; }
+        private string MethodName { get; }
 
         /// <summary>
         ///     Class name
         /// </summary>
-        public string ClassName { get; }
+        private string ClassName { get; }
 
         /// <summary>
         ///     Full qualified name of method

--- a/src/FunFair.CodeAnalysis/Helpers/Rules.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/Rules.cs
@@ -33,5 +33,7 @@ namespace FunFair.CodeAnalysis.Helpers
         public const string MockBaseClassInstancesMustBeInternal = @"FFS0029";
         public const string MockBaseClassInstancesMustBeSealed = @"FFS0030";
         public const string RuleDontUseConcurrentDictionary = @"FFS0031";
+        public const string RuleDontUseBuildInAddOrUpdateConcurrentDictionary = @"FFS0032";
+        public const string RuleDontUseBuildInGetOrAddConcurrentDictionary = @"FFS0033";
     }
 }

--- a/src/FunFair.CodeAnalysis/ProhibitedMethodInvocationsDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ProhibitedMethodInvocationsDiagnosticsAnalyzer.cs
@@ -21,10 +21,39 @@ namespace FunFair.CodeAnalysis
 
         private static readonly ProhibitedMethodsSpec[] BannedMethods =
         {
-            new(ruleId: Rules.RuleDontUseAssertTrueWithoutMessage, title: @"Avoid use of assert method without message", message: "Only use Assert.True with message parameter",
-                sourceClass: "Xunit.Assert", bannedMethod: "True", new[] {new[] {"bool"}}),
-            new(ruleId: Rules.RuleDontUseAssertFalseWithoutMessage, title: @"Avoid use of assert method without message", message:
-                "Only use Assert.False with message parameter", sourceClass: "Xunit.Assert", bannedMethod: "False", new[] {new[] {"bool"}})
+            new(ruleId: Rules.RuleDontUseAssertTrueWithoutMessage, title: @"Avoid use of assert method without message", message: "Only use Assert.True with message parameter", sourceClass:
+                "Xunit.Assert", bannedMethod: "True", new[] {new[] {new ParameterSpecs("bool")}}),
+            new(ruleId: Rules.RuleDontUseAssertFalseWithoutMessage, title: @"Avoid use of assert method without message", message: "Only use Assert.False with message parameter", sourceClass:
+                "Xunit.Assert", bannedMethod: "False", new[] {new[] {new ParameterSpecs("bool")}}),
+            new(ruleId: Rules.RuleDontUseBuildInAddOrUpdateConcurrentDictionary, title: @"Avoid use of the built in AddOrUpdate methods", message:
+                "Don't use any of the built in AddOrUpdate methods, instead FunFair.Common.Extensions.ConcurrentDictionaryExtensions.AddOrUpdate can be used", sourceClass:
+                "NonBlocking.ConcurrentDictionary`2", bannedMethod: "AddOrUpdate",
+                new[]
+                {
+                    new[]
+                    {
+                        new ParameterSpecs("TKey"),
+                        new ParameterSpecs(type: "System.Func<TKey, TValue>", allowLambdaExpressions: false),
+                        new ParameterSpecs(type: "System.Func<TKey, TValue, TValue>", allowLambdaExpressions: false)
+                    }
+                }),
+            new(ruleId: Rules.RuleDontUseBuildInAddOrUpdateConcurrentDictionary, title: @"Avoid use of the built in AddOrUpdate methods", message:
+                "Don't use any of the built in AddOrUpdate methods, instead FunFair.Common.Extensions.ConcurrentDictionaryExtensions.AddOrUpdate can be used", sourceClass:
+                "NonBlocking.ConcurrentDictionary`2", bannedMethod: "AddOrUpdate",
+                new[] {new[] {new ParameterSpecs("TKey"), new ParameterSpecs(type: "TValue"), new ParameterSpecs(type: "System.Func<TKey, TValue, TValue>", allowLambdaExpressions: false)}}),
+            new(ruleId: Rules.RuleDontUseBuildInGetOrAddConcurrentDictionary, title: @"Avoid use of the built in GetOrAdd methods", message:
+                "Don't use any of the built in GetOrAdd methods, instead FunFair.Common.Extensions.ConcurrentDictionaryExtensions.GetOrAdd can be used", sourceClass:
+                "NonBlocking.ConcurrentDictionary`2", bannedMethod: "GetOrAdd", new[] {new[] {new ParameterSpecs("TKey"), new ParameterSpecs(type: "TValue")}}),
+            new(ruleId: Rules.RuleDontUseBuildInGetOrAddConcurrentDictionary, title: @"Avoid use of the built in GetOrAdd methods", message:
+                "Don't use any of the built in GetOrAdd methods, instead FunFair.Common.Extensions.ConcurrentDictionaryExtensions.GetOrAdd can be used", sourceClass:
+                "NonBlocking.ConcurrentDictionary`2", bannedMethod: "GetOrAdd", new[]
+                                                                                {
+                                                                                    new[]
+                                                                                    {
+                                                                                        new ParameterSpecs("TKey"),
+                                                                                        new ParameterSpecs(type: "System.Func<TKey, TValue>", allowLambdaExpressions: false)
+                                                                                    }
+                                                                                }),
         };
 
         /// <inheritdoc />
@@ -47,7 +76,7 @@ namespace FunFair.CodeAnalysis
         /// <param name="compilationStartContext"></param>
         private static void PerformCheck(CompilationStartAnalysisContext compilationStartContext)
         {
-            IReadOnlyDictionary<Mapping, IReadOnlyList<IMethodSymbol>> cachedSymbols = BuildCachedSymbols(compilationStartContext.Compilation);
+            IReadOnlyDictionary<ProhibitedMethodsSpec, IReadOnlyList<IMethodSymbol>> cachedSymbols = BuildCachedSymbols(compilationStartContext.Compilation);
 
             void LookForBannedMethods(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
             {
@@ -59,26 +88,38 @@ namespace FunFair.CodeAnalysis
                 {
                     IMethodSymbol? memberSymbol = MethodSymbolHelper.FindInvokedMemberSymbol(invocation: invocation, syntaxNodeAnalysisContext: syntaxNodeAnalysisContext);
 
-                    // check if there is at least one rule that correspond to invocation method
                     if (memberSymbol == null)
                     {
                         continue;
                     }
 
-                    Mapping mapping = new(className: SymbolDisplay.ToDisplayString(memberSymbol.ContainingType), methodName: memberSymbol.Name);
+                    IReadOnlyList<InvocationArgument> invocationArguments = GetInvocationArguments(invocationExpressionSyntax: invocation, methodSymbol: memberSymbol)
+                        .ToList();
 
-                    if (!cachedSymbols.TryGetValue(key: mapping, out IReadOnlyList<IMethodSymbol> allowedMethodSignatures))
+                    if (invocationArguments.Count == 0)
                     {
                         continue;
                     }
 
-                    IEnumerable<ProhibitedMethodsSpec> prohibitedMethods = BannedMethods.Where(predicate: rule => rule.QualifiedName == mapping.QualifiedName);
+                    string? fullyQualifiedName = memberSymbol.ContainingType.ToFullyQualifiedName();
 
-                    foreach (ProhibitedMethodsSpec prohibitedMethod in prohibitedMethods)
+                    if (fullyQualifiedName == null)
                     {
-                        if (!IsInvocationAllowed(invocationArguments: memberSymbol, methodSignatures: allowedMethodSignatures))
+                        continue;
+                    }
+
+                    Mapping mapping = new(className: fullyQualifiedName, methodName: memberSymbol.Name);
+
+                    foreach (ProhibitedMethodsSpec prohibitedMethodSpecs in BannedMethods.Where(predicate: rule => rule.QualifiedName == mapping.QualifiedName))
+                    {
+                        if (!cachedSymbols.TryGetValue(key: prohibitedMethodSpecs, out IReadOnlyList<IMethodSymbol> symbolsForProhibitedMethod))
                         {
-                            syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(descriptor: prohibitedMethod.Rule, invocation.GetLocation()));
+                            continue;
+                        }
+
+                        if (IsBannedMethodSignature(invocationArguments: invocationArguments, prohibitedMethodsSpecs: prohibitedMethodSpecs, prohibitedMethodsSymbols: symbolsForProhibitedMethod))
+                        {
+                            syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(descriptor: prohibitedMethodSpecs.Rule, invocation.GetLocation()));
                         }
                     }
                 }
@@ -87,15 +128,13 @@ namespace FunFair.CodeAnalysis
             compilationStartContext.RegisterSyntaxNodeAction(action: LookForBannedMethods, SyntaxKind.MethodDeclaration);
         }
 
-        private static IReadOnlyDictionary<Mapping, IReadOnlyList<IMethodSymbol>> BuildCachedSymbols(Compilation compilation)
+        private static IReadOnlyDictionary<ProhibitedMethodsSpec, IReadOnlyList<IMethodSymbol>> BuildCachedSymbols(Compilation compilation)
         {
-            Dictionary<Mapping, IReadOnlyList<IMethodSymbol>> cachedSymbols = new();
+            Dictionary<ProhibitedMethodsSpec, IReadOnlyList<IMethodSymbol>> cachedSymbols = new();
 
             foreach (ProhibitedMethodsSpec rule in BannedMethods)
             {
-                Mapping mapping = new(className: rule.SourceClass, methodName: rule.BannedMethod);
-
-                if (cachedSymbols.ContainsKey(mapping))
+                if (cachedSymbols.ContainsKey(rule))
                 {
                     continue;
                 }
@@ -107,6 +146,7 @@ namespace FunFair.CodeAnalysis
                     continue;
                 }
 
+                // get all method overloads
                 IMethodSymbol[] methodSignatures = sourceClassType.GetMembers()
                                                                   .Where(predicate: x => x.Name == rule.BannedMethod)
                                                                   .OfType<IMethodSymbol>()
@@ -114,20 +154,47 @@ namespace FunFair.CodeAnalysis
 
                 if (methodSignatures.Length > 0)
                 {
-                    cachedSymbols.Add(key: mapping, GetAllowedSignaturesForMethod(methodSignatures: methodSignatures, ruleSignatures: rule.BannedSignatures));
+                    cachedSymbols.Add(key: rule, RemoveAllowedSignaturesForMethod(methodSignatures: methodSignatures, ruleSignatures: rule.BannedSignatures));
                 }
             }
 
             return cachedSymbols;
         }
 
+        private static IEnumerable<bool> CheckIfInvocationArgumentUseLambdaExpression(InvocationExpressionSyntax invocation)
+        {
+            return invocation.ArgumentList.Arguments.Select(arg => arg.Expression is SimpleLambdaExpressionSyntax or ParenthesizedLambdaExpressionSyntax);
+        }
+
+        private static IEnumerable<InvocationArgument> GetInvocationArguments(InvocationExpressionSyntax invocationExpressionSyntax, IMethodSymbol methodSymbol)
+        {
+            bool[] lambdaParameters = CheckIfInvocationArgumentUseLambdaExpression(invocationExpressionSyntax)
+                .ToArray();
+
+            IList<InvocationArgument> invocationArguments = new List<InvocationArgument>();
+
+            if (lambdaParameters.Length != methodSymbol.Parameters.Length)
+            {
+                return invocationArguments;
+            }
+
+            for (int i = 0; i < methodSymbol.Parameters.Length; i++)
+            {
+                invocationArguments.Add(new InvocationArgument(parameterSymbol: methodSymbol.Parameters[i]
+                                                                                            .OriginalDefinition,
+                                                               lambdaParameters[i]));
+            }
+
+            return invocationArguments;
+        }
+
         /// <summary>
-        ///     Filter method signatures to get only signatures allowed by rule
+        ///     Filter method signatures to get only signatures banned by rules
         /// </summary>
         /// <param name="methodSignatures">All signatures of one method</param>
         /// <param name="ruleSignatures">All banned signatures</param>
         /// <returns>Collection of allowed signatures.</returns>
-        private static IReadOnlyList<IMethodSymbol> GetAllowedSignaturesForMethod(IEnumerable<IMethodSymbol> methodSignatures, IEnumerable<IEnumerable<string>> ruleSignatures)
+        private static IReadOnlyList<IMethodSymbol> RemoveAllowedSignaturesForMethod(IEnumerable<IMethodSymbol> methodSignatures, IEnumerable<IEnumerable<ParameterSpecs>> ruleSignatures)
         {
             if (methodSignatures == null)
             {
@@ -139,32 +206,71 @@ namespace FunFair.CodeAnalysis
                 throw new ArgumentException(message: "Unknown rule signature");
             }
 
-            List<IMethodSymbol> methodSignatureList = methodSignatures.ToList();
+            IEnumerable<IMethodSymbol> methodSymbols = methodSignatures.ToList();
+            List<IMethodSymbol> methodSignatureList = new();
 
-            foreach (IEnumerable<string> ruleSignature in ruleSignatures)
+            // iterate over each rule to find symbol signature that correspond with rule it self
+            foreach (IEnumerable<ParameterSpecs> ruleSignature in ruleSignatures)
             {
-                methodSignatureList.RemoveAll(match: methodSymbol => methodSymbol
-                                                                     .Parameters.Select(selector: parameterSymbol => SymbolDisplay.ToDisplayString(parameterSymbol.Type))
-                                                                     .SequenceEqual(ruleSignature));
+                IEnumerable<string> ruleSignatureTypes = ruleSignature.Select(signature => signature.Type);
+
+                IEnumerable<IMethodSymbol> bannedMethodSymbols = methodSymbols.Where(methodSymbol => methodSymbol
+                                                                                                     .Parameters
+                                                                                                     .Select(selector: parameterSymbol => SymbolDisplay.ToDisplayString(parameterSymbol.Type))
+                                                                                                     .SequenceEqual(ruleSignatureTypes));
+
+                methodSignatureList.AddRange(bannedMethodSymbols);
             }
 
             return methodSignatureList;
         }
 
-        /// <summary>
-        ///     Check if invoked method signature is in list of allowed signatures
-        /// </summary>
-        /// <param name="invocationArguments">Arguments used in invocation of method</param>
-        /// <param name="methodSignatures">List of all valid signatures for method</param>
-        /// <returns>true, if the method was allowed; otherwise, false.</returns>
-        private static bool IsInvocationAllowed(IMethodSymbol invocationArguments, IEnumerable<IMethodSymbol> methodSignatures)
+        private static bool IsBannedMethodSignature(IReadOnlyList<InvocationArgument> invocationArguments,
+                                                    ProhibitedMethodsSpec prohibitedMethodsSpecs,
+                                                    IReadOnlyList<IMethodSymbol> prohibitedMethodsSymbols)
         {
-            return methodSignatures.Any(predicate: methodSignature => methodSignature.Parameters.SequenceEqual(invocationArguments.Parameters));
+            // check if method is prohibited
+            if (prohibitedMethodsSymbols.Any(symbol => symbol.Parameters.SequenceEqual(invocationArguments.Select(invocationArgument => invocationArgument.ParameterSymbol))))
+            {
+                return !LambdaCheckNeeded(invocationArguments: invocationArguments, prohibitedMethodsSpecs: prohibitedMethodsSpecs, out IReadOnlyList<ParameterSpecs> bannedSignature) ||
+                       IncorrectUseOfLambdas(invocationArguments: invocationArguments, bannedSignature: bannedSignature);
+            }
+
+            return false;
+        }
+
+        private static bool IncorrectUseOfLambdas(IReadOnlyList<InvocationArgument> invocationArguments, IReadOnlyList<ParameterSpecs> bannedSignature)
+        {
+            for (int i = 0; i < bannedSignature.Count; i++)
+            {
+                if (!bannedSignature[i]
+                    .AllowLambdaExpressions && invocationArguments[i]
+                    .IsLambdaExpression)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool LambdaCheckNeeded(IReadOnlyList<InvocationArgument> invocationArguments, ProhibitedMethodsSpec prohibitedMethodsSpecs, out IReadOnlyList<ParameterSpecs> bannedSignature)
+        {
+            // invocation is present in symbol and we can check if invocation is using lambdas according to defined rule
+            // transform to parameters specs to match parameters between invocation and prohibited method
+            IEnumerable<string> invocationParameterSpecs = invocationArguments.Select(argument => SymbolDisplay.ToDisplayString(argument.ParameterSymbol.Type));
+
+            // find rule signature that we need
+            bannedSignature = prohibitedMethodsSpecs.BannedSignatures.First(ruleSignature => ruleSignature.Select(parameterSpecs => parameterSpecs.Type)
+                                                                                                          .SequenceEqual(invocationParameterSpecs))
+                                                    .ToList();
+
+            return !bannedSignature.All(parameter => parameter.AllowLambdaExpressions);
         }
 
         private sealed class ProhibitedMethodsSpec
         {
-            public ProhibitedMethodsSpec(string ruleId, string title, string message, string sourceClass, string bannedMethod, IEnumerable<IEnumerable<string>> bannedSignatures)
+            public ProhibitedMethodsSpec(string ruleId, string title, string message, string sourceClass, string bannedMethod, IEnumerable<IEnumerable<ParameterSpecs>> bannedSignatures)
             {
                 this.SourceClass = sourceClass;
                 this.BannedMethod = bannedMethod;
@@ -179,7 +285,7 @@ namespace FunFair.CodeAnalysis
             /// <summary>
             ///     List of all method signatures that are banned, every signature is given with array of types in exact parameter order
             /// </summary>
-            public IEnumerable<IEnumerable<string>> BannedSignatures { get; }
+            public IEnumerable<IEnumerable<ParameterSpecs>> BannedSignatures { get; }
 
             public DiagnosticDescriptor Rule { get; }
 
@@ -187,6 +293,110 @@ namespace FunFair.CodeAnalysis
             ///     Full qualified name of method
             /// </summary>
             public string QualifiedName => string.Concat(str0: this.SourceClass, str1: ".", str2: this.BannedMethod);
+        }
+
+        private sealed class ParameterSpecs : IEquatable<ParameterSpecs>
+        {
+            public ParameterSpecs(string type, bool allowLambdaExpressions = true)
+            {
+                this.Type = type;
+                this.AllowLambdaExpressions = allowLambdaExpressions;
+            }
+
+            public string Type { get; }
+
+            public bool AllowLambdaExpressions { get; }
+
+            /// <inheritdoc />
+            public bool Equals(ParameterSpecs? other)
+            {
+                return AreEqual(this, right: other);
+            }
+
+            /// <inheritdoc />
+            public override bool Equals(object? obj)
+            {
+                if (!(obj is ParameterSpecs other))
+                {
+                    return false;
+                }
+
+                return AreEqual(this, right: other);
+            }
+
+            /// <inheritdoc />
+            public override int GetHashCode()
+            {
+                unchecked // Overflow is fine, just wrap
+                {
+                    int hash = 17;
+
+                    hash = (hash * 23) + this.Type.GetHashCode();
+                    hash = (hash * 23) + this.AllowLambdaExpressions.GetHashCode();
+
+                    return hash;
+                }
+            }
+
+            /// <summary>
+            ///     Equality comparison via operator overload
+            /// </summary>
+            /// <param name="left">The first <see cref="ParameterSpecs" />.</param>
+            /// <param name="right">The second <see cref="ParameterSpecs" />.</param>
+            /// <returns>true, if they are the same; otherwise, false.</returns>
+            public static bool operator ==(ParameterSpecs? left, ParameterSpecs? right)
+            {
+                return AreEqual(left: left, right: right);
+            }
+
+            /// <summary>
+            ///     Inequality comparison via operator overload.
+            /// </summary>
+            /// <param name="left">The first <see cref="ParameterSpecs" />.</param>
+            /// <param name="right">The second <see cref="ParameterSpecs" />.</param>
+            /// <returns>true, if they are different; otherwise, false.</returns>
+            public static bool operator !=(ParameterSpecs? left, ParameterSpecs? right)
+            {
+                return !AreEqual(left: left, right: right);
+            }
+
+            private static bool AreEqual(ParameterSpecs? left, ParameterSpecs? right)
+            {
+                static bool Equality(ParameterSpecs l, ParameterSpecs r)
+                {
+                    return l.Type == r.Type && l.AllowLambdaExpressions == r.AllowLambdaExpressions;
+                }
+
+                if (ReferenceEquals(objA: left, objB: right))
+                {
+                    return true;
+                }
+
+                if (ReferenceEquals(objA: null, objB: right))
+                {
+                    return false;
+                }
+
+                if (ReferenceEquals(objA: null, objB: left))
+                {
+                    return false;
+                }
+
+                return Equality(l: left, r: right);
+            }
+        }
+
+        private sealed class InvocationArgument
+        {
+            public InvocationArgument(IParameterSymbol parameterSymbol, bool isLambdaExpression)
+            {
+                this.ParameterSymbol = parameterSymbol;
+                this.IsLambdaExpression = isLambdaExpression;
+            }
+
+            public IParameterSymbol ParameterSymbol { get; }
+
+            public bool IsLambdaExpression { get; }
         }
     }
 }

--- a/src/FunFair.CodeAnalysis/ProhibitedMethodWithStrictParametersInvocationDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ProhibitedMethodWithStrictParametersInvocationDiagnosticsAnalyzer.cs
@@ -21,17 +21,8 @@ namespace FunFair.CodeAnalysis
         private static readonly ProhibitedMethodsSpec[] ForcedMethods =
         {
             new(ruleId: Rules.RuleDontUseSubstituteReceivedWithZeroNumberOfCalls, title: "Avoid use of received with zero call count", message:
-                "Only use Received with expected call count greater than 0, use DidNotReceived instead if 0 call received expected", sourceClass:
-                "NSubstitute.SubstituteExtensions", forcedMethod: "Received", new[]
-                                                                              {
-                                                                                  new[]
-                                                                                  {
-                                                                                      new ParameterSpec(
-                                                                                          name: "requiredNumberOfCalls",
-                                                                                          type: "NumericLiteralExpression",
-                                                                                          value: "0")
-                                                                                  }
-                                                                              })
+                "Only use Received with expected call count greater than 0, use DidNotReceived instead if 0 call received expected", sourceClass: "NSubstitute.SubstituteExtensions", forcedMethod:
+                "Received", new[] {new[] {new ParameterSpec(name: "requiredNumberOfCalls", type: "NumericLiteralExpression", value: "0")}})
         };
 
         /// <inheritdoc />
@@ -70,7 +61,7 @@ namespace FunFair.CodeAnalysis
                         continue;
                     }
 
-                    Mapping mapping = new(methodName: memberSymbol.Name, SymbolDisplay.ToDisplayString(memberSymbol.ContainingType));
+                    Mapping mapping = new(SymbolDisplay.ToDisplayString(memberSymbol.ContainingType), methodName: memberSymbol.Name);
 
                     IEnumerable<ProhibitedMethodsSpec> forcedMethods = ForcedMethods.Where(predicate: rule => rule.QualifiedName == mapping.QualifiedName);
 
@@ -129,12 +120,7 @@ namespace FunFair.CodeAnalysis
 
         private sealed class ProhibitedMethodsSpec
         {
-            public ProhibitedMethodsSpec(string ruleId,
-                                         string title,
-                                         string message,
-                                         string sourceClass,
-                                         string forcedMethod,
-                                         IEnumerable<IEnumerable<ParameterSpec>> bannedSignatures)
+            public ProhibitedMethodsSpec(string ruleId, string title, string message, string sourceClass, string forcedMethod, IEnumerable<IEnumerable<ParameterSpec>> bannedSignatures)
             {
                 this.SourceClass = sourceClass;
                 this.ForcedMethod = forcedMethod;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above that includes the Jira Ticket -->
Block built-in methods for NonBlocking concurrent dictionary

# Description
<!--- Describe your changes in detail -->

# Related Issue\Feature

<!--- Please link to the issue or feature: -->

# How Has This Been Tested

- [ ] All unit tests pass.
- [ ] All integration tests pass.
- [ ] Manual Testing:
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Types of changes

<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Removed no-longer used code

## Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

<!--- Insert Deployment configuration changes here -->

# Checklist

<!--- Go over all the following points, and put an 'x' in all the boxes once they are true. -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] There are no Resharper\static code analysis errors anywhere in the solution.
- [ ] I have ONLY run a code clean-up on any files I have modified to make sure they are in the correct format and no others.
- [ ] I have added tests to cover my changes.
- [ ] I have run the code and quickly verified it all works to my satisfaction.
- [ ] All new/modified code has sufficient logging to be able to diagnose what is wrong.
- [ ] All new and existing tests passed.
- [ ] All new/modified public interfaces/classes have are documented with xmldoc comments.
- [ ] Unreleased section of CHANGELOG.md has been updated with details of this PR.
