### PR TITLE
Block usage of built-in methods in NonBlocking concurrent directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Added
+- Check if built-in methods are used for NonBlocking.ConcurrentDictionary<,> and force usage of extension methods under FunFair.Common.Extensions.ConcurrentDictionaryExtensions
 ### Fixed
 ### Changed
 - FF-1429 - Updated TeamCity.VSTest.TestAdapter to 1.0.26

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Static Code analysis Repo for FunFair Server dotnet projects.
 |FFS0029|Classes derived from ``MockBase<T>`` should be ``internal``|
 |FFS0030|Classes derived from ``MockBase<T>`` should be ``sealed``|
 |FFS0031|Avoid using ``System.Collections.Concurrent.ConcurrentDictionary<,>`` - Use ``NonBlocking.ConcurrentDictionary<,>``|
-
+|FFS0032|Avoid using ``NonBlocing.ConcurrentDictionary<,>.AddOrUpdate`` - Use ``FunFair.Common.Extensions.ConcurrentDictionaryExtensions.AddOrUpdate``|
+|FFS0033|Avoid using ``NonBlocing.ConcurrentDictionary<,>.GetOrAdd`` - Use ``FunFair.Common.Extensions.ConcurrentDictionaryExtensions.GetOrAdd``|
 
 ## Changelog
 

--- a/src/.idea/.idea.FunFair.CodeAnalysis/.idea/aws.xml
+++ b/src/.idea/.idea.FunFair.CodeAnalysis/.idea/aws.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="accountSettings">
+    <option name="activeProfile" value="profile:default" />
+    <option name="activeRegion" value="us-east-1" />
+    <option name="recentlyUsedProfiles">
+      <list>
+        <option value="profile:default" />
+      </list>
+    </option>
+    <option name="recentlyUsedRegions">
+      <list>
+        <option value="us-east-1" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/src/FunFair.CodeAnalysis.Tests/Helpers/WellKnownMetadataReferences.cs
+++ b/src/FunFair.CodeAnalysis.Tests/Helpers/WellKnownMetadataReferences.cs
@@ -41,8 +41,8 @@ namespace FunFair.CodeAnalysis.Tests.Helpers
 
         public static readonly MetadataReference SuppressMessage = MetadataReference.CreateFromFile(typeof(SuppressMessageAttribute).Assembly.Location);
 
-        public static readonly MetadataReference ConcurrentDictionary  = MetadataReference.CreateFromFile(typeof(ConcurrentDictionary<,>).Assembly.Location);
+        public static readonly MetadataReference ConcurrentDictionary = MetadataReference.CreateFromFile(typeof(ConcurrentDictionary<,>).Assembly.Location);
 
-        public static readonly MetadataReference NonBlockingConcurrentDictionary  = MetadataReference.CreateFromFile(typeof(NonBlocking.ConcurrentDictionary<,>).Assembly.Location);
+        public static readonly MetadataReference NonBlockingConcurrentDictionary = MetadataReference.CreateFromFile(typeof(NonBlocking.ConcurrentDictionary<,>).Assembly.Location);
     }
 }

--- a/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodInvocationsDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/ProhibitedMethodInvocationsDiagnosticsAnalyzerTests.cs
@@ -19,7 +19,6 @@ namespace FunFair.CodeAnalysis.Tests
         {
             const string test = @"
      using Xunit;
-
      namespace ConsoleApplication1
      {
          class TypeName
@@ -39,10 +38,8 @@ namespace FunFair.CodeAnalysis.Tests
         {
             const string test = @"
     using Xunit;
-
     namespace ConsoleApplication1
     {
-
         class TypeName
         {
             void Test()
@@ -56,7 +53,7 @@ namespace FunFair.CodeAnalysis.Tests
                                             Id = "FFS0010",
                                             Message = @"Only use Assert.False with message parameter",
                                             Severity = DiagnosticSeverity.Error,
-                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 11, column: 17)}
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 9, column: 17)}
                                         };
 
             return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Assert}, expected);
@@ -67,10 +64,8 @@ namespace FunFair.CodeAnalysis.Tests
         {
             const string test = @"
     using Xunit;
-
     namespace ConsoleApplication1
     {
-
         class TypeName
         {
             void Test()
@@ -88,7 +83,6 @@ namespace FunFair.CodeAnalysis.Tests
         {
             const string test = @"
      using Xunit;
-
      namespace ConsoleApplication1
      {
          class TypeName
@@ -104,10 +98,206 @@ namespace FunFair.CodeAnalysis.Tests
                                             Id = "FFS0009",
                                             Message = @"Only use Assert.True with message parameter",
                                             Severity = DiagnosticSeverity.Error,
-                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 10, column: 18)}
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 9, column: 18)}
                                         };
 
             return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Assert}, expected);
+        }
+
+        [Fact]
+        public Task ShouldRaiseErrorForAddOrUpdateAsync()
+        {
+            const string test = @"
+     using NonBlocking;
+     namespace ConsoleApplication1
+     {
+         class TypeName
+         {
+             void Test()
+             {
+                 ConcurrentDictionary<int,int> dictionary = new ConcurrentDictionary<int,int>();
+                 dictionary.AddOrUpdate(key: 1, addValueFactory: (x) => x + 1, updateValueFactory: (x,y)=> x+y+1);
+             }
+         }
+     }";
+            DiagnosticResult expected = new()
+                                        {
+                                            Id = "FFS0032",
+                                            Message = @"Don't use any of the built in AddOrUpdate methods, instead FunFair.Common.Extensions.ConcurrentDictionaryExtensions.AddOrUpdate can be used",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 10, column: 18)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.NonBlockingConcurrentDictionary}, expected: expected);
+        }
+
+        [Fact]
+        public Task ShouldRaiseErrorForAddOrUpdateWithOutAddValueFactoryAsync()
+        {
+            const string test = @"
+     using NonBlocking;
+     namespace ConsoleApplication1
+     {
+         class TypeName
+         {
+            void Test()
+             {
+                 ConcurrentDictionary<int,int> dictionary = new ConcurrentDictionary<int,int>();
+                 dictionary.AddOrUpdate(key: 1, addValue: 1, updateValueFactory: (x, y) => x + y);
+             }
+         }
+     }";
+            DiagnosticResult expected = new()
+                                        {
+                                            Id = "FFS0032",
+                                            Message = @"Don't use any of the built in AddOrUpdate methods, instead FunFair.Common.Extensions.ConcurrentDictionaryExtensions.AddOrUpdate can be used",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 10, column: 18)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.NonBlockingConcurrentDictionary}, expected: expected);
+        }
+
+        [Fact]
+        public Task ShouldRaiseForAddOrUpdateAsync()
+        {
+            const string test = @"
+     using NonBlocking;
+     namespace ConsoleApplication1
+     {
+         class TypeName
+         {
+             int Update(int x, int y){
+                return x+y+1;
+            }
+            int Add(int x){
+                return x+1;
+            }
+             void Test()
+             {
+                 ConcurrentDictionary<int,int> dictionary = new ConcurrentDictionary<int,int>();
+                 dictionary.AddOrUpdate(key: 1, addValueFactory: this.Add, updateValueFactory: this.Update);
+             }
+         }
+     }";
+
+            DiagnosticResult expected = new()
+                                        {
+                                            Id = "FFS0032",
+                                            Message = @"Don't use any of the built in AddOrUpdate methods, instead FunFair.Common.Extensions.ConcurrentDictionaryExtensions.AddOrUpdate can be used",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 16, column: 18)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.NonBlockingConcurrentDictionary}, expected: expected);
+        }
+
+        [Fact]
+        public Task ShouldRaiseForAddOrUpdateWithAddValueFactoryAsync()
+        {
+            const string test = @"
+     using NonBlocking;
+     namespace ConsoleApplication1
+     {
+         class TypeName
+         {
+             int Update(int x, int y){
+                return x+y+1;
+            }
+             void Test()
+             {
+                 ConcurrentDictionary<int,int> dictionary = new ConcurrentDictionary<int,int>();
+                 dictionary.AddOrUpdate(key: 1, addValue: 1, updateValueFactory: this.Update);
+             }
+         }
+     }";
+
+            DiagnosticResult expected = new()
+                                        {
+                                            Id = "FFS0032",
+                                            Message = @"Don't use any of the built in AddOrUpdate methods, instead FunFair.Common.Extensions.ConcurrentDictionaryExtensions.AddOrUpdate can be used",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 13, column: 18)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.NonBlockingConcurrentDictionary}, expected);
+        }
+
+        [Fact]
+        public Task ShouldRaiseErrorForGetOrAddAsync()
+        {
+            const string test = @"
+     using NonBlocking;
+     namespace ConsoleApplication1
+     {
+         class TypeName
+         {
+            void Test()
+             {
+                 ConcurrentDictionary<int,int> dictionary = new ConcurrentDictionary<int,int>();
+                 dictionary.GetOrAdd(key: 1, valueFactory: i => i);
+             }
+         }
+     }";
+            DiagnosticResult expected = new()
+                                        {
+                                            Id = "FFS0033",
+                                            Message = @"Don't use any of the built in GetOrAdd methods, instead FunFair.Common.Extensions.ConcurrentDictionaryExtensions.GetOrAdd can be used",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 10, column: 18)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.NonBlockingConcurrentDictionary}, expected);
+        }
+
+        [Fact]
+        public Task ShouldRaiseForGetOrAddWithValueFactoryAsync()
+        {
+            const string test = @"
+     using NonBlocking;
+     namespace ConsoleApplication1
+     {
+         class TypeName
+         {
+             int ValueFactory(int x){
+                return x+1;
+            }
+             void Test()
+             {
+                 ConcurrentDictionary<int,int> dictionary = new ConcurrentDictionary<int,int>();
+                 dictionary.GetOrAdd(key: 1, valueFactory: this.ValueFactory);
+             }
+         }
+     }";
+            DiagnosticResult expected = new()
+                                        {
+                                            Id = "FFS0033",
+                                            Message = @"Don't use any of the built in GetOrAdd methods, instead FunFair.Common.Extensions.ConcurrentDictionaryExtensions.GetOrAdd can be used",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 13, column: 18)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.NonBlockingConcurrentDictionary}, expected);
+        }
+
+        [Fact]
+        public Task ShouldAllowGetOrAddAsync()
+        {
+            const string test = @"
+     using NonBlocking;
+     namespace ConsoleApplication1
+     {
+         class TypeName
+         {
+            void Test()
+             {
+                 ConcurrentDictionary<int,int> dictionary = new ConcurrentDictionary<int,int>();
+                 dictionary.GetOrAdd(key: 1, value: 1);
+             }
+         }
+     }";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.NonBlockingConcurrentDictionary});
         }
     }
 }

--- a/src/FunFair.CodeAnalysis/Helpers/Mapping.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/Mapping.cs
@@ -21,12 +21,12 @@ namespace FunFair.CodeAnalysis.Helpers
         /// <summary>
         ///     Method name
         /// </summary>
-        public string MethodName { get; }
+        private string MethodName { get; }
 
         /// <summary>
         ///     Class name
         /// </summary>
-        public string ClassName { get; }
+        private string ClassName { get; }
 
         /// <summary>
         ///     Full qualified name of method

--- a/src/FunFair.CodeAnalysis/Helpers/Rules.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/Rules.cs
@@ -33,5 +33,7 @@ namespace FunFair.CodeAnalysis.Helpers
         public const string MockBaseClassInstancesMustBeInternal = @"FFS0029";
         public const string MockBaseClassInstancesMustBeSealed = @"FFS0030";
         public const string RuleDontUseConcurrentDictionary = @"FFS0031";
+        public const string RuleDontUseBuildInAddOrUpdateConcurrentDictionary = @"FFS0032";
+        public const string RuleDontUseBuildInGetOrAddConcurrentDictionary = @"FFS0033";
     }
 }

--- a/src/FunFair.CodeAnalysis/ProhibitedMethodInvocationsDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ProhibitedMethodInvocationsDiagnosticsAnalyzer.cs
@@ -181,15 +181,6 @@ namespace FunFair.CodeAnalysis
 
             return methodSignatures.Any(predicate: methodSignature => methodSignature.Parameters.Select(x => SymbolDisplay.ToDisplayString(x.OriginalDefinition))
                                                                                      .SequenceEqual(invocationParameters));
-
-            // // check if method is prohibited
-            // if (prohibitedMethodsSymbols.Any(symbol => symbol.Parameters.SequenceEqual(invocationArguments.Select(invocationArgument => invocationArgument.ParameterSymbol))))
-            // {
-            //     return !LambdaCheckNeeded(invocationArguments: invocationArguments, prohibitedMethodsSpecs: prohibitedMethodsSpecs, out IReadOnlyList<ParameterSpecs> bannedSignature) ||
-            //            IncorrectUseOfLambdas(invocationArguments: invocationArguments, bannedSignature: bannedSignature);
-            // }
-            //
-            // return false;
         }
 
         private sealed class ProhibitedMethodsSpec

--- a/src/FunFair.CodeAnalysis/ProhibitedMethodInvocationsDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ProhibitedMethodInvocationsDiagnosticsAnalyzer.cs
@@ -21,10 +21,19 @@ namespace FunFair.CodeAnalysis
 
         private static readonly ProhibitedMethodsSpec[] BannedMethods =
         {
-            new(ruleId: Rules.RuleDontUseAssertTrueWithoutMessage, title: @"Avoid use of assert method without message", message: "Only use Assert.True with message parameter",
-                sourceClass: "Xunit.Assert", bannedMethod: "True", new[] {new[] {"bool"}}),
-            new(ruleId: Rules.RuleDontUseAssertFalseWithoutMessage, title: @"Avoid use of assert method without message", message:
-                "Only use Assert.False with message parameter", sourceClass: "Xunit.Assert", bannedMethod: "False", new[] {new[] {"bool"}})
+            new(ruleId: Rules.RuleDontUseAssertTrueWithoutMessage, title: @"Avoid use of assert method without message", message: "Only use Assert.True with message parameter", sourceClass:
+                "Xunit.Assert", bannedMethod: "True", new[] {new[] {"bool"}}),
+            new(ruleId: Rules.RuleDontUseAssertFalseWithoutMessage, title: @"Avoid use of assert method without message", message: "Only use Assert.False with message parameter", sourceClass:
+                "Xunit.Assert", bannedMethod: "False", new[] {new[] {"bool"}}),
+            new(ruleId: Rules.RuleDontUseBuildInAddOrUpdateConcurrentDictionary, title: @"Avoid use of the built in AddOrUpdate methods", message:
+                "Don't use any of the built in AddOrUpdate methods, instead FunFair.Common.Extensions.ConcurrentDictionaryExtensions.AddOrUpdate can be used", sourceClass:
+                "NonBlocking.ConcurrentDictionary`2", bannedMethod: "AddOrUpdate", new[] {new[] {"TKey", "System.Func<TKey, TValue>", "System.Func<TKey, TValue, TValue>"}}),
+            new(ruleId: Rules.RuleDontUseBuildInAddOrUpdateConcurrentDictionary, title: @"Avoid use of the built in AddOrUpdate methods", message:
+                "Don't use any of the built in AddOrUpdate methods, instead FunFair.Common.Extensions.ConcurrentDictionaryExtensions.AddOrUpdate can be used", sourceClass:
+                "NonBlocking.ConcurrentDictionary`2", bannedMethod: "AddOrUpdate", new[] {new[] {"TKey", "TValue", "System.Func<TKey, TValue, TValue>"}}),
+            new(ruleId: Rules.RuleDontUseBuildInGetOrAddConcurrentDictionary, title: @"Avoid use of the built in GetOrAdd methods", message:
+                "Don't use any of the built in GetOrAdd methods, instead FunFair.Common.Extensions.ConcurrentDictionaryExtensions.GetOrAdd can be used", sourceClass:
+                "NonBlocking.ConcurrentDictionary`2", bannedMethod: "GetOrAdd", new[] {new[] {"TKey", "System.Func<TKey, TValue>"}}),
         };
 
         /// <inheritdoc />
@@ -47,7 +56,7 @@ namespace FunFair.CodeAnalysis
         /// <param name="compilationStartContext"></param>
         private static void PerformCheck(CompilationStartAnalysisContext compilationStartContext)
         {
-            IReadOnlyDictionary<Mapping, IReadOnlyList<IMethodSymbol>> cachedSymbols = BuildCachedSymbols(compilationStartContext.Compilation);
+            IReadOnlyDictionary<ProhibitedMethodsSpec, IReadOnlyList<IMethodSymbol>> cachedSymbols = BuildCachedSymbols(compilationStartContext.Compilation);
 
             void LookForBannedMethods(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
             {
@@ -65,18 +74,23 @@ namespace FunFair.CodeAnalysis
                         continue;
                     }
 
-                    Mapping mapping = new(className: SymbolDisplay.ToDisplayString(memberSymbol.ContainingType), methodName: memberSymbol.Name);
+                    string? fullyQualifiedName = memberSymbol.ContainingType.ToFullyQualifiedName();
 
-                    if (!cachedSymbols.TryGetValue(key: mapping, out IReadOnlyList<IMethodSymbol> allowedMethodSignatures))
+                    if (fullyQualifiedName == null)
                     {
                         continue;
                     }
 
-                    IEnumerable<ProhibitedMethodsSpec> prohibitedMethods = BannedMethods.Where(predicate: rule => rule.QualifiedName == mapping.QualifiedName);
+                    Mapping mapping = new(methodName: memberSymbol.Name, className: fullyQualifiedName);
 
-                    foreach (ProhibitedMethodsSpec prohibitedMethod in prohibitedMethods)
+                    foreach (ProhibitedMethodsSpec prohibitedMethod in BannedMethods.Where(predicate: rule => rule.QualifiedName == mapping.QualifiedName))
                     {
-                        if (!IsInvocationAllowed(invocationArguments: memberSymbol, methodSignatures: allowedMethodSignatures))
+                        if (!cachedSymbols.TryGetValue(key: prohibitedMethod, out IReadOnlyList<IMethodSymbol> prohibitedMethodSignatures))
+                        {
+                            continue;
+                        }
+
+                        if (IsBannedMethodSignature(invocationArguments: memberSymbol, methodSignatures: prohibitedMethodSignatures))
                         {
                             syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(descriptor: prohibitedMethod.Rule, invocation.GetLocation()));
                         }
@@ -87,15 +101,13 @@ namespace FunFair.CodeAnalysis
             compilationStartContext.RegisterSyntaxNodeAction(action: LookForBannedMethods, SyntaxKind.MethodDeclaration);
         }
 
-        private static IReadOnlyDictionary<Mapping, IReadOnlyList<IMethodSymbol>> BuildCachedSymbols(Compilation compilation)
+        private static IReadOnlyDictionary<ProhibitedMethodsSpec, IReadOnlyList<IMethodSymbol>> BuildCachedSymbols(Compilation compilation)
         {
-            Dictionary<Mapping, IReadOnlyList<IMethodSymbol>> cachedSymbols = new();
+            Dictionary<ProhibitedMethodsSpec, IReadOnlyList<IMethodSymbol>> cachedSymbols = new();
 
             foreach (ProhibitedMethodsSpec rule in BannedMethods)
             {
-                Mapping mapping = new(className: rule.SourceClass, methodName: rule.BannedMethod);
-
-                if (cachedSymbols.ContainsKey(mapping))
+                if (cachedSymbols.ContainsKey(rule))
                 {
                     continue;
                 }
@@ -107,6 +119,7 @@ namespace FunFair.CodeAnalysis
                     continue;
                 }
 
+                // get all method overloads
                 IMethodSymbol[] methodSignatures = sourceClassType.GetMembers()
                                                                   .Where(predicate: x => x.Name == rule.BannedMethod)
                                                                   .OfType<IMethodSymbol>()
@@ -114,7 +127,7 @@ namespace FunFair.CodeAnalysis
 
                 if (methodSignatures.Length > 0)
                 {
-                    cachedSymbols.Add(key: mapping, GetAllowedSignaturesForMethod(methodSignatures: methodSignatures, ruleSignatures: rule.BannedSignatures));
+                    cachedSymbols.Add(key: rule, RemoveAllowedSignaturesForMethod(methodSignatures: methodSignatures, ruleSignatures: rule.BannedSignatures));
                 }
             }
 
@@ -122,12 +135,12 @@ namespace FunFair.CodeAnalysis
         }
 
         /// <summary>
-        ///     Filter method signatures to get only signatures allowed by rule
+        ///     Filter method signatures to get only signatures banned by rules
         /// </summary>
         /// <param name="methodSignatures">All signatures of one method</param>
         /// <param name="ruleSignatures">All banned signatures</param>
         /// <returns>Collection of allowed signatures.</returns>
-        private static IReadOnlyList<IMethodSymbol> GetAllowedSignaturesForMethod(IEnumerable<IMethodSymbol> methodSignatures, IEnumerable<IEnumerable<string>> ruleSignatures)
+        private static IReadOnlyList<IMethodSymbol> RemoveAllowedSignaturesForMethod(IEnumerable<IMethodSymbol> methodSignatures, IEnumerable<IEnumerable<string>> ruleSignatures)
         {
             if (methodSignatures == null)
             {
@@ -139,13 +152,18 @@ namespace FunFair.CodeAnalysis
                 throw new ArgumentException(message: "Unknown rule signature");
             }
 
-            List<IMethodSymbol> methodSignatureList = methodSignatures.ToList();
+            IEnumerable<IMethodSymbol> methodSymbols = methodSignatures.ToList();
+            List<IMethodSymbol> methodSignatureList = new();
 
+            // iterate over each rule to find symbol signature that correspond with rule it self
             foreach (IEnumerable<string> ruleSignature in ruleSignatures)
             {
-                methodSignatureList.RemoveAll(match: methodSymbol => methodSymbol
-                                                                     .Parameters.Select(selector: parameterSymbol => SymbolDisplay.ToDisplayString(parameterSymbol.Type))
-                                                                     .SequenceEqual(ruleSignature));
+                IEnumerable<IMethodSymbol> bannedMethodSymbols = methodSymbols.Where(methodSymbol => methodSymbol
+                                                                                                     .Parameters
+                                                                                                     .Select(selector: parameterSymbol => SymbolDisplay.ToDisplayString(parameterSymbol.Type))
+                                                                                                     .SequenceEqual(ruleSignature));
+
+                methodSignatureList.AddRange(bannedMethodSymbols);
             }
 
             return methodSignatureList;
@@ -155,11 +173,23 @@ namespace FunFair.CodeAnalysis
         ///     Check if invoked method signature is in list of allowed signatures
         /// </summary>
         /// <param name="invocationArguments">Arguments used in invocation of method</param>
-        /// <param name="methodSignatures">List of all valid signatures for method</param>
+        /// <param name="methodSignatures">List of all blocked signatures for method</param>
         /// <returns>true, if the method was allowed; otherwise, false.</returns>
-        private static bool IsInvocationAllowed(IMethodSymbol invocationArguments, IEnumerable<IMethodSymbol> methodSignatures)
+        private static bool IsBannedMethodSignature(IMethodSymbol invocationArguments, IEnumerable<IMethodSymbol> methodSignatures)
         {
-            return methodSignatures.Any(predicate: methodSignature => methodSignature.Parameters.SequenceEqual(invocationArguments.Parameters));
+            IEnumerable<string> invocationParameters = invocationArguments.Parameters.Select(parameter => SymbolDisplay.ToDisplayString(parameter.OriginalDefinition));
+
+            return methodSignatures.Any(predicate: methodSignature => methodSignature.Parameters.Select(x => SymbolDisplay.ToDisplayString(x.OriginalDefinition))
+                                                                                     .SequenceEqual(invocationParameters));
+
+            // // check if method is prohibited
+            // if (prohibitedMethodsSymbols.Any(symbol => symbol.Parameters.SequenceEqual(invocationArguments.Select(invocationArgument => invocationArgument.ParameterSymbol))))
+            // {
+            //     return !LambdaCheckNeeded(invocationArguments: invocationArguments, prohibitedMethodsSpecs: prohibitedMethodsSpecs, out IReadOnlyList<ParameterSpecs> bannedSignature) ||
+            //            IncorrectUseOfLambdas(invocationArguments: invocationArguments, bannedSignature: bannedSignature);
+            // }
+            //
+            // return false;
         }
 
         private sealed class ProhibitedMethodsSpec


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above that includes the Jira Ticket -->
Block usage of built-in methods in NonBlocking concurrent directory

# Description
<!--- Describe your changes in detail -->

# Related Issue\Feature

<!--- Please link to the issue or feature: -->

# How Has This Been Tested

- [ ] All unit tests pass.
- [ ] All integration tests pass.
- [ ] Manual Testing:
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Types of changes

<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Removed no-longer used code

## Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

<!--- Insert Deployment configuration changes here -->

# Checklist

<!--- Go over all the following points, and put an 'x' in all the boxes once they are true. -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] There are no Resharper\static code analysis errors anywhere in the solution.
- [ ] I have ONLY run a code clean-up on any files I have modified to make sure they are in the correct format and no others.
- [x] I have added tests to cover my changes.
- [ ] I have run the code and quickly verified it all works to my satisfaction.
- [ ] All new/modified code has sufficient logging to be able to diagnose what is wrong.
- [x] All new and existing tests passed.
- [ ] All new/modified public interfaces/classes have are documented with xmldoc comments.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.
