### PR TITLE
Checks that test classes do not contain mutable properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ## [Unreleased]
 ### Added
 - Check that test classes do not define mutable fields.
+- Check that test classes do not define mutable properties
 ### Fixed
 ### Changed
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Added
+- Check that test classes do not define mutable fields.
 ### Fixed
 ### Changed
 ### Removed

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Static Code analysis Repo for FunFair Server dotnet projects.
 |FFS0033|Avoid using ``NonBlocing.ConcurrentDictionary<,>.GetOrAdd`` - Use ``FunFair.Common.Extensions.ConcurrentDictionaryExtensions.GetOrAdd``|
 |FFS0034|Avoid using ``Microsoft.Extensions.Configuration.ConfigurationBuilder.AddJsonFile`` with reload set to true|
 |FFS0035|Checks that test classes do not define mutable fields|
+|FFS0036|Checks that test classes do not define mutable properties|
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Static Code analysis Repo for FunFair Server dotnet projects.
 |FFS0032|Avoid using ``NonBlocing.ConcurrentDictionary<,>.AddOrUpdate`` - Use ``FunFair.Common.Extensions.ConcurrentDictionaryExtensions.AddOrUpdate``|
 |FFS0033|Avoid using ``NonBlocing.ConcurrentDictionary<,>.GetOrAdd`` - Use ``FunFair.Common.Extensions.ConcurrentDictionaryExtensions.GetOrAdd``|
 |FFS0034|Avoid using ``Microsoft.Extensions.Configuration.ConfigurationBuilder.AddJsonFile`` with reload set to true|
+|FFS0035|Checks that test classes do not define mutable fields|
 
 ## Changelog
 

--- a/src/FunFair.CodeAnalysis.Tests/TestClassFieldsAnalysisDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/TestClassFieldsAnalysisDiagnosticsAnalyzerTests.cs
@@ -1,0 +1,95 @@
+﻿using System.Threading.Tasks;
+using FunFair.CodeAnalysis.Tests.Helpers;
+using FunFair.CodeAnalysis.Tests.Verifiers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace FunFair.CodeAnalysis.Tests
+{
+    public sealed class TestClassFieldsAnalysisDiagnosticsAnalyzerTests : CodeFixVerifier
+    {
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new TestClassFieldsAnalysisDiagnosticsAnalyzer();
+        }
+
+        [Fact]
+        public Task NonTestClassAllowedMutableFieldsAsync()
+        {
+            const string test = @"
+public sealed class Test {
+    private int _test;
+
+    public void Exec()
+    {
+        ++_test;
+    }
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(test);
+        }
+
+        [Fact]
+        public Task TestClassProhibitedMutableFieldsAsync()
+        {
+            const string test = @"
+using FunFair.Test.Common;
+
+public sealed class Test : TestBase{
+    private int _test;
+
+    public void Exec()
+    {
+        ++_test;
+    }
+}";
+
+            DiagnosticResult expected = new()
+                                        {
+                                            Id = "FFS0035",
+                                            Message = "Fields in test classes should be read-only or const",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 5, column: 5)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Xunit, WellKnownMetadataReferences.FunFairTestCommon}, expected);
+        }
+
+        [Fact]
+        public Task TestClassAllowedReadOnlyFieldAsync()
+        {
+            const string test = @"
+using FunFair.Test.Common;
+
+public sealed class Test : TestBase{
+    private readonly int _test = 42;
+
+    public int Value()
+    {
+        return _test;
+    }
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Xunit, WellKnownMetadataReferences.FunFairTestCommon});
+        }
+
+        [Fact]
+        public Task TestClassAllowedConstFieldAsync()
+        {
+            const string test = @"
+using FunFair.Test.Common;
+
+public sealed class Test : TestBase{
+    private const int _test = 42;
+
+    public int Value()
+    {
+        return _test;
+    }
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Xunit, WellKnownMetadataReferences.FunFairTestCommon});
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis.Tests/TestClassFieldsAnalysisDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/TestClassFieldsAnalysisDiagnosticsAnalyzerTests.cs
@@ -18,7 +18,7 @@ namespace FunFair.CodeAnalysis.Tests
         public Task NonTestClassAllowedMutableFieldsAsync()
         {
             const string test = @"
-public sealed class Test {
+public sealed class NormalClass {
     private int _test;
 
     public void Exec()

--- a/src/FunFair.CodeAnalysis.Tests/TestClassPropertyAnalysisDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/TestClassPropertyAnalysisDiagnosticsAnalyzerTests.cs
@@ -15,10 +15,10 @@ namespace FunFair.CodeAnalysis.Tests
         }
 
         [Fact]
-        public Task NonTestClassAllowedMutableFieldsAsync()
+        public Task NonTestClassAllowedMutablePropertiesAsync()
         {
             const string test = @"
-public sealed class Test {
+public sealed class NormalClass {
     public int TestValue {get; set;}
 
 }";

--- a/src/FunFair.CodeAnalysis.Tests/TestClassPropertyAnalysisDiagnosticsAnalyzerTests.cs
+++ b/src/FunFair.CodeAnalysis.Tests/TestClassPropertyAnalysisDiagnosticsAnalyzerTests.cs
@@ -1,0 +1,182 @@
+﻿using System.Threading.Tasks;
+using FunFair.CodeAnalysis.Tests.Helpers;
+using FunFair.CodeAnalysis.Tests.Verifiers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace FunFair.CodeAnalysis.Tests
+{
+    public sealed class TestClassPropertyAnalysisDiagnosticsAnalyzerTests : CodeFixVerifier
+    {
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new TestClassPropertyAnalysisDiagnosticsAnalyzer();
+        }
+
+        [Fact]
+        public Task NonTestClassAllowedMutableFieldsAsync()
+        {
+            const string test = @"
+public sealed class Test {
+    public int TestValue {get; set;}
+
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(test);
+        }
+
+        [Fact]
+        public Task TestClassProhibitedMutablePropertyAsync()
+        {
+            const string test = @"
+using FunFair.Test.Common;
+
+public sealed class Test : TestBase {
+
+    public int Value {get; set;}
+
+}";
+
+            DiagnosticResult expected = new()
+                                        {
+                                            Id = "FFS0036",
+                                            Message = "Properties in test classes should be read-only or const",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 6, column: 5)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Xunit, WellKnownMetadataReferences.FunFairTestCommon}, expected);
+        }
+
+        [Fact]
+        public Task TestClassAllowedGetOnlyPropertyAsync()
+        {
+            const string test = @"
+using FunFair.Test.Common;
+
+public sealed class Test : TestBase {
+
+    Test() {
+        Value = 42;
+    }
+
+    public int Value {get;}
+
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Xunit, WellKnownMetadataReferences.FunFairTestCommon});
+        }
+
+        [Fact]
+        public Task TestClassAllowedGetOnlyPropertyWithLambdaAsync()
+        {
+            const string test = @"
+using FunFair.Test.Common;
+
+public sealed class Test : TestBase {
+
+    public int Value => 42;
+
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Xunit, WellKnownMetadataReferences.FunFairTestCommon});
+        }
+
+        [Fact]
+        public Task TestClassAllowedGetOnlyPropertyWithCompileTimeAsync()
+        {
+            const string test = @"
+using FunFair.Test.Common;
+
+public sealed class Test : TestBase {
+
+    public int Value {get;} = 42;
+
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Xunit, WellKnownMetadataReferences.FunFairTestCommon});
+        }
+
+        [Fact]
+        public Task TestClassAllowedGetOnlyPropertyWithWxplicitBodyAsync()
+        {
+            const string test = @"
+using FunFair.Test.Common;
+
+public sealed class Test : TestBase {
+
+    public int Value {
+            get
+            {
+                return 42;
+            }
+        }
+}";
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Xunit, WellKnownMetadataReferences.FunFairTestCommon});
+        }
+
+        [Fact]
+        public Task TestClassAllowedInitOnlyPropertyAsync()
+        {
+            const string test = @"
+using FunFair.Test.Common;
+
+public sealed class Test : TestBase {
+
+    Test() {
+        Value = 42;
+    }
+
+    public int Value {get; set;}
+
+}";
+
+            DiagnosticResult expected = new()
+                                        {
+                                            Id = "FFS0036",
+                                            Message = "Properties in test classes should be read-only or const",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 10, column: 5)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Xunit, WellKnownMetadataReferences.FunFairTestCommon}, expected);
+        }
+
+        [Fact]
+        public Task TestClassProhibitedMutablePropertyWithExplicitBodyAsync()
+        {
+            const string test = @"
+using FunFair.Test.Common;
+
+public sealed class Test : TestBase {
+    private int _value;
+    Test() {
+        _value = 42;
+    }
+
+    public int Value {
+            get
+            {
+                return _value;
+            }
+            set
+            {
+                _value = value;
+            }
+    }
+}";
+
+            DiagnosticResult expected = new()
+                                        {
+                                            Id = "FFS0036",
+                                            Message = "Properties in test classes should be read-only or const",
+                                            Severity = DiagnosticSeverity.Error,
+                                            Locations = new[] {new DiagnosticResultLocation(path: "Test0.cs", line: 10, column: 5)}
+                                        };
+
+            return this.VerifyCSharpDiagnosticAsync(source: test, new[] {WellKnownMetadataReferences.Xunit, WellKnownMetadataReferences.FunFairTestCommon}, expected);
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/ClassAnalysisDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ClassAnalysisDiagnosticsAnalyzer.cs
@@ -40,7 +40,7 @@ namespace FunFair.CodeAnalysis
 
         private static void MustBeReadOnly(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
         {
-            if (!(syntaxNodeAnalysisContext.Node is ClassDeclarationSyntax classDeclarationSyntax))
+            if (syntaxNodeAnalysisContext.Node is not ClassDeclarationSyntax classDeclarationSyntax)
             {
                 return;
             }

--- a/src/FunFair.CodeAnalysis/ClassVisibilityDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ClassVisibilityDiagnosticsAnalyzer.cs
@@ -90,17 +90,15 @@ namespace FunFair.CodeAnalysis
                     return false;
                 }
 
-                for (INamedTypeSymbol? parent = containingType.BaseType; parent != null; parent = parent.BaseType)
-                {
-                    INamedTypeSymbol originalDefinition = parent.OriginalDefinition;
+                return containingType.BaseClasses()
+                                     .Any(this.IsMatchingClass);
+            }
 
-                    if (SymbolDisplay.ToDisplayString(originalDefinition) == this.ClassName)
-                    {
-                        return true;
-                    }
-                }
+            private bool IsMatchingClass(INamedTypeSymbol typeSymbol)
+            {
+                INamedTypeSymbol originalDefinition = typeSymbol.OriginalDefinition;
 
-                return false;
+                return SymbolDisplay.ToDisplayString(originalDefinition) == this.ClassName;
             }
 
             public bool HasCorrectClassModifier(ClassDeclarationSyntax classDeclarationSyntax)

--- a/src/FunFair.CodeAnalysis/ClassVisibilityDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ClassVisibilityDiagnosticsAnalyzer.cs
@@ -52,15 +52,14 @@ namespace FunFair.CodeAnalysis
 
         private static void CheckClassVisibility(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
         {
-            if (!(syntaxNodeAnalysisContext.Node is ClassDeclarationSyntax classDeclarationSyntax))
+            if (syntaxNodeAnalysisContext.Node is not ClassDeclarationSyntax classDeclarationSyntax)
             {
                 return;
             }
 
             foreach (ConfiguredClass classDefinition in Classes)
             {
-                if (classDefinition.TypeMatchesClass(syntaxNodeAnalysisContext: syntaxNodeAnalysisContext) &&
-                    !classDefinition.HasCorrectClassModifier(classDeclarationSyntax: classDeclarationSyntax))
+                if (classDefinition.TypeMatchesClass(syntaxNodeAnalysisContext: syntaxNodeAnalysisContext) && !classDefinition.HasCorrectClassModifier(classDeclarationSyntax: classDeclarationSyntax))
                 {
                     syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(descriptor: classDefinition.Rule, classDeclarationSyntax.GetLocation()));
                 }

--- a/src/FunFair.CodeAnalysis/Helpers/Rules.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/Rules.cs
@@ -37,5 +37,6 @@ namespace FunFair.CodeAnalysis.Helpers
         public const string RuleDontUseBuildInGetOrAddConcurrentDictionary = @"FFS0033";
         public const string RuleDontUseConfigurationBuilderAddJsonFileWithReload = @"FFS0034";
         public const string RuleTestClassesShouldNotDefineMutableFields = @"FFS0035";
+        public const string RuleTestClassesShouldNotDefineMutableProperties = @"FFS0036";
     }
 }

--- a/src/FunFair.CodeAnalysis/Helpers/Rules.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/Rules.cs
@@ -36,5 +36,6 @@ namespace FunFair.CodeAnalysis.Helpers
         public const string RuleDontUseBuildInAddOrUpdateConcurrentDictionary = @"FFS0032";
         public const string RuleDontUseBuildInGetOrAddConcurrentDictionary = @"FFS0033";
         public const string RuleDontUseConfigurationBuilderAddJsonFileWithReload = @"FFS0034";
+        public const string RuleTestClassesShouldNotDefineMutableFields = @"FFS0035";
     }
 }

--- a/src/FunFair.CodeAnalysis/Helpers/TestDetection.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/TestDetection.cs
@@ -27,15 +27,13 @@ namespace FunFair.CodeAnalysis.Helpers
                 return false;
             }
 
-            for (INamedTypeSymbol? parent = containingType.ContainingType; parent != null; parent = parent.BaseType)
-            {
-                if (SymbolDisplay.ToDisplayString(parent) == "FunFair.Test.Common.TestBase")
-                {
-                    return true;
-                }
-            }
+            return containingType.BaseClasses()
+                                 .Any(IsTestBase);
+        }
 
-            return false;
+        private static bool IsTestBase(INamedTypeSymbol symbol)
+        {
+            return symbol.ToFullyQualifiedName() == "FunFair.Test.Common.TestBase";
         }
 
         private static bool IsTestMethodAttribute(string attributeType)

--- a/src/FunFair.CodeAnalysis/Helpers/TestDetection.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/TestDetection.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FunFair.CodeAnalysis.Helpers
+{
+    internal static class TestDetection
+    {
+        public static bool IsTestMethod(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext, MethodDeclarationSyntax methodDeclarationSyntax)
+        {
+            return methodDeclarationSyntax.AttributeLists.SelectMany(selector: al => al.Attributes)
+                                          .Select(attribute => syntaxNodeAnalysisContext.SemanticModel.GetTypeInfo(attribute))
+                                          .Select(ti => ti.Type)
+                                          .RemoveNulls()
+                                          .Any(ti => IsTestMethodAttribute(ti.ToDisplayString()));
+        }
+
+        public static bool IsDerivedFromTestBase(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
+        {
+            ISymbol? containingType = syntaxNodeAnalysisContext.ContainingSymbol;
+
+            if (containingType == null)
+            {
+                return false;
+            }
+
+            for (INamedTypeSymbol? parent = containingType.ContainingType; parent != null; parent = parent.BaseType)
+            {
+                if (SymbolDisplay.ToDisplayString(parent) == "FunFair.Test.Common.TestBase")
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsTestMethodAttribute(string attributeType)
+        {
+            return StringComparer.InvariantCultureIgnoreCase.Equals(x: attributeType, y: @"Xunit.FactAttribute") ||
+                   StringComparer.InvariantCultureIgnoreCase.Equals(x: attributeType, y: @"Xunit.TheoryAttribute");
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/Helpers/TestDetection.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/TestDetection.cs
@@ -27,7 +27,7 @@ namespace FunFair.CodeAnalysis.Helpers
                 return false;
             }
 
-            return containingType.BaseClasses()
+            return containingType.ContainingType.BaseClasses()
                                  .Any(IsTestBase);
         }
 

--- a/src/FunFair.CodeAnalysis/Helpers/TypeHelpers.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/TypeHelpers.cs
@@ -5,9 +5,9 @@ namespace FunFair.CodeAnalysis.Helpers
 {
     internal static class TypeHelpers
     {
-        public static IEnumerable<INamedTypeSymbol> BaseClasses(this ISymbol containingType)
+        public static IEnumerable<INamedTypeSymbol> BaseClasses(this INamedTypeSymbol sourceType)
         {
-            for (INamedTypeSymbol? parent = containingType.ContainingType; parent != null; parent = parent.BaseType)
+            for (INamedTypeSymbol? parent = sourceType; parent != null; parent = parent.BaseType)
             {
                 yield return parent;
             }

--- a/src/FunFair.CodeAnalysis/Helpers/TypeHelpers.cs
+++ b/src/FunFair.CodeAnalysis/Helpers/TypeHelpers.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace FunFair.CodeAnalysis.Helpers
+{
+    internal static class TypeHelpers
+    {
+        public static IEnumerable<INamedTypeSymbol> BaseClasses(this ISymbol containingType)
+        {
+            for (INamedTypeSymbol? parent = containingType.ContainingType; parent != null; parent = parent.BaseType)
+            {
+                yield return parent;
+            }
+        }
+    }
+}

--- a/src/FunFair.CodeAnalysis/NullableDirectiveDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/NullableDirectiveDiagnosticsAnalyzer.cs
@@ -36,7 +36,7 @@ namespace FunFair.CodeAnalysis
         {
             void LookForProhibition(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
             {
-                if (!(syntaxNodeAnalysisContext.Node is NullableDirectiveTriviaSyntax pragmaWarningDirective))
+                if (syntaxNodeAnalysisContext.Node is not NullableDirectiveTriviaSyntax pragmaWarningDirective)
                 {
                     return;
                 }

--- a/src/FunFair.CodeAnalysis/ProhibitedPragmaDiagnosticsAnalyzercs.cs
+++ b/src/FunFair.CodeAnalysis/ProhibitedPragmaDiagnosticsAnalyzercs.cs
@@ -98,7 +98,7 @@ namespace FunFair.CodeAnalysis
 
             void LookForBannedMethods(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
             {
-                if (!(syntaxNodeAnalysisContext.Node is PragmaWarningDirectiveTriviaSyntax pragmaWarningDirective))
+                if (syntaxNodeAnalysisContext.Node is not PragmaWarningDirectiveTriviaSyntax pragmaWarningDirective)
                 {
                     return;
                 }

--- a/src/FunFair.CodeAnalysis/ReThrowingExceptionShouldSpecifyInnerExceptionDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/ReThrowingExceptionShouldSpecifyInnerExceptionDiagnosticsAnalyzer.cs
@@ -41,7 +41,7 @@ namespace FunFair.CodeAnalysis
 
         private static void MustBeReadOnly(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
         {
-            if (!(syntaxNodeAnalysisContext.Node is CatchClauseSyntax catchClause))
+            if (syntaxNodeAnalysisContext.Node is not CatchClauseSyntax catchClause)
             {
                 return;
             }

--- a/src/FunFair.CodeAnalysis/RecordAnalysisDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/RecordAnalysisDiagnosticsAnalyzer.cs
@@ -40,7 +40,7 @@ namespace FunFair.CodeAnalysis
 
         private static void MustBeReadOnly(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
         {
-            if (!(syntaxNodeAnalysisContext.Node is RecordDeclarationSyntax recordDeclarationSyntax))
+            if (syntaxNodeAnalysisContext.Node is not RecordDeclarationSyntax recordDeclarationSyntax)
             {
                 return;
             }

--- a/src/FunFair.CodeAnalysis/StructAnalysisDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/StructAnalysisDiagnosticsAnalyzer.cs
@@ -40,7 +40,7 @@ namespace FunFair.CodeAnalysis
 
         private static void MustBeReadOnly(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
         {
-            if (!(syntaxNodeAnalysisContext.Node is StructDeclarationSyntax structDeclarationSyntax))
+            if (syntaxNodeAnalysisContext.Node is not StructDeclarationSyntax structDeclarationSyntax)
             {
                 return;
             }

--- a/src/FunFair.CodeAnalysis/SuppressMessageDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/SuppressMessageDiagnosticsAnalyzer.cs
@@ -44,14 +44,13 @@ namespace FunFair.CodeAnalysis
             }
 
             compilationStartContext.RegisterSyntaxNodeAction(action: syntaxNodeAnalysisContext =>
-                                                                         MustDeriveFromTestBase(syntaxNodeAnalysisContext: syntaxNodeAnalysisContext,
-                                                                                                sourceClassType: sourceClassType),
+                                                                         MustDeriveFromTestBase(syntaxNodeAnalysisContext: syntaxNodeAnalysisContext, sourceClassType: sourceClassType),
                                                              SyntaxKind.Attribute);
         }
 
         private static void MustDeriveFromTestBase(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext, INamedTypeSymbol sourceClassType)
         {
-            if (!(syntaxNodeAnalysisContext.Node is AttributeSyntax methodDeclarationSyntax))
+            if (syntaxNodeAnalysisContext.Node is not AttributeSyntax methodDeclarationSyntax)
             {
                 return;
             }

--- a/src/FunFair.CodeAnalysis/TestClassAnalysisDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/TestClassAnalysisDiagnosticsAnalyzer.cs
@@ -44,15 +44,16 @@ namespace FunFair.CodeAnalysis
                 return;
             }
 
-            if (!TestDetection.IsTestMethod(syntaxNodeAnalysisContext: syntaxNodeAnalysisContext, methodDeclarationSyntax: methodDeclarationSyntax))
-            {
-                return;
-            }
-
-            if (!TestDetection.IsDerivedFromTestBase(syntaxNodeAnalysisContext))
+            if (IsTestMethodInClassNotDerivedFromTestBase(syntaxNodeAnalysisContext: syntaxNodeAnalysisContext, methodDeclarationSyntax: methodDeclarationSyntax))
             {
                 syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(descriptor: Rule, methodDeclarationSyntax.GetLocation()));
             }
+        }
+
+        private static bool IsTestMethodInClassNotDerivedFromTestBase(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext, MethodDeclarationSyntax methodDeclarationSyntax)
+        {
+            return TestDetection.IsTestMethod(syntaxNodeAnalysisContext: syntaxNodeAnalysisContext, methodDeclarationSyntax: methodDeclarationSyntax) &&
+                   !TestDetection.IsDerivedFromTestBase(syntaxNodeAnalysisContext);
         }
     }
 }

--- a/src/FunFair.CodeAnalysis/TestClassFieldsAnalysisDiagnosticsAnalyzer.cs
+++ b/src/FunFair.CodeAnalysis/TestClassFieldsAnalysisDiagnosticsAnalyzer.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Immutable;
+using FunFair.CodeAnalysis.Helpers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace FunFair.CodeAnalysis
+{
+    /// <summary>
+    ///     Looks for issues with class declarations
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class TestClassFieldsAnalysisDiagnosticsAnalyzer : DiagnosticAnalyzer
+    {
+        private const string CATEGORY = "Classes";
+
+        private static readonly DiagnosticDescriptor Rule = RuleHelpers.CreateRule(code: Rules.RuleTestClassesShouldNotDefineMutableFields,
+                                                                                   category: CATEGORY,
+                                                                                   title: "Fields in test classes should be read-only or const",
+                                                                                   message: "Fields in test classes should be read-only or const");
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => new[] {Rule}.ToImmutableArray();
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterCompilationStartAction(PerformCheck);
+        }
+
+        private static void PerformCheck(CompilationStartAnalysisContext compilationStartContext)
+        {
+            compilationStartContext.RegisterSyntaxNodeAction(action: FieldMustBeReadOnly, SyntaxKind.FieldDeclaration);
+        }
+
+        private static void FieldMustBeReadOnly(SyntaxNodeAnalysisContext syntaxNodeAnalysisContext)
+        {
+            if (!TestDetection.IsDerivedFromTestBase(syntaxNodeAnalysisContext))
+            {
+                return;
+            }
+
+            if (syntaxNodeAnalysisContext.Node is FieldDeclarationSyntax fieldDeclarationSyntax)
+            {
+                if (fieldDeclarationSyntax.Modifiers.Any(SyntaxKind.ReadOnlyKeyword) || fieldDeclarationSyntax.Modifiers.Any(SyntaxKind.ConstKeyword))
+                {
+                    // its read-only or const.
+                    return;
+                }
+
+                syntaxNodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(descriptor: Rule, fieldDeclarationSyntax.GetLocation()));
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above that includes the Jira Ticket -->

# Description
<!--- Describe your changes in detail -->
Added checks that test do not contain mutable properties and fields - after struggling with spaghetti of mutable fields that are seemed randomly set through different methods, rather than being returned by the things that set them so the tests are easy to read.

# Related Issue\Feature

<!--- Please link to the issue or feature: -->

# How Has This Been Tested

- [x] All unit tests pass.
- [x] All integration tests pass.
- [ ] Manual Testing:
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Types of changes

<!--- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Removed no-longer used code

## Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md

<!--- Insert Deployment configuration changes here -->

# Checklist

<!--- Go over all the following points, and put an 'x' in all the boxes once they are true. -->
<!-- Note that you can just click these after submission and it will remember the tick for you -->

- [x] There are no Resharper\static code analysis errors anywhere in the solution.
- [x] I have ONLY run a code clean-up on any files I have modified to make sure they are in the correct format and no others.
- [x] I have added tests to cover my changes.
- [x] I have run the code and quickly verified it all works to my satisfaction.
- [x] All new/modified code has sufficient logging to be able to diagnose what is wrong.
- [x] All new and existing tests passed.
- [x] All new/modified public interfaces/classes have are documented with xmldoc comments.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.
